### PR TITLE
Don't create an items list in set_many.

### DIFF
--- a/pymemcache/client.py
+++ b/pymemcache/client.py
@@ -315,13 +315,12 @@ class Client(object):
           then a successful return does not guarantee that any keys were
           successfully set (just that the keys were successfully sent).
         """
-        if not values:
-            return True
 
         # TODO: make this more performant by sending all the values first, then
         # waiting for all the responses.
-        for key, value in values.items():
+        for key, value in values.iteritems():
             self.set(key, value, expire, noreply)
+        return True
 
     def add(self, key, value, expire=0, noreply=True):
         """

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -128,6 +128,27 @@ def test_set_exception():
     tools.assert_equal(client.buf, '')
 
 
+def test_set_many_success():
+    client = Client(None)
+    client.sock = MockSocket(['STORED\r\n'])
+    result = client.set_many({'key' : 'value'}, noreply=False)
+    tools.assert_equal(result, True)
+    tools.assert_equal(client.sock.closed, False)
+    tools.assert_equal(len(client.sock.send_bufs), 1)
+
+
+def test_set_many_exception():
+    client = Client(None)
+    client.sock = MockSocket(['STORED\r\n', Exception('fail')])
+
+    def _set():
+        client.set_many({'key' : 'value', 'other' : 'value'}, noreply=False)
+
+    tools.assert_raises(Exception, _set)
+    tools.assert_equal(client.sock, None)
+    tools.assert_equal(client.buf, '')
+
+
 def test_add_stored():
     client = Client(None)
     client.sock = MockSocket(['STORED\r', '\n'])


### PR DESCRIPTION
There's another performance note here anyhow, but this at least removes the intermediate list from `items()`.

Also, makes the docstring not lie :D, since before it only returned `True` for empty values, not for anytime the sets all succeeded.

(Though TBH unless there's something more complicated planned or this is some compatibility with other memcache API thing I'd just have had this and set return `None` [i.e. do nothing special] if it were me. Exceptions are good enough signals that something's up).
