### PR TITLE
Let users provide Client with a Custom socket module

### DIFF
--- a/pymemcache/client.py
+++ b/pymemcache/client.py
@@ -265,12 +265,14 @@ class Client(object):
         self.buf = ''
 
     def _connect(self):
-        sock = self.socket_module.socket(self.socket_module.AF_INET, self.socket_module.SOCK_STREAM)
+        sock = self.socket_module.socket(self.socket_module.AF_INET,
+                                         self.socket_module.SOCK_STREAM)
         sock.settimeout(self.connect_timeout)
         sock.connect(self.server)
         sock.settimeout(self.timeout)
         if self.no_delay:
-            sock.setsockopt(self.socket_module.IPPROTO_TCP, self.socket_module.TCP_NODELAY, 1)
+            sock.setsockopt(self.socket_module.IPPROTO_TCP,
+                            self.socket_module.TCP_NODELAY, 1)
         self.sock = sock
 
     def close(self):

--- a/pymemcache/test/integration.py
+++ b/pymemcache/test/integration.py
@@ -16,7 +16,8 @@ import argparse
 import json
 import socket
 
-from pymemcache.client import Client, MemcacheClientError, MemcacheUnknownCommandError
+from pymemcache.client import (Client, MemcacheClientError,
+                               MemcacheUnknownCommandError)
 from pymemcache.client import MemcacheIllegalInputError
 from nose import tools
 

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -42,7 +42,7 @@ class MockSocket(object):
         if isinstance(value, Exception):
             raise value
         return value
-    
+
     def settimeout(self, timeout):
         self.timeouts.append(timeout)
 
@@ -59,7 +59,6 @@ class MockSocketModule(object):
 
     def __getattr__(self, name):
         return getattr(socket, name)
-
 
 
 def test_set_success():
@@ -153,7 +152,7 @@ def test_set_exception():
 def test_set_many_success():
     client = Client(None)
     client.sock = MockSocket(['STORED\r\n'])
-    result = client.set_many({'key' : 'value'}, noreply=False)
+    result = client.set_many({'key': 'value'}, noreply=False)
     tools.assert_equal(result, True)
     tools.assert_equal(client.sock.closed, False)
     tools.assert_equal(len(client.sock.send_bufs), 1)
@@ -164,7 +163,7 @@ def test_set_many_exception():
     client.sock = MockSocket(['STORED\r\n', Exception('fail')])
 
     def _set():
-        client.set_many({'key' : 'value', 'other' : 'value'}, noreply=False)
+        client.set_many({'key': 'value', 'other': 'value'}, noreply=False)
 
     tools.assert_raises(Exception, _set)
     tools.assert_equal(client.sock, None)
@@ -305,7 +304,6 @@ def test_cr_nl_boundaries():
                               'END\r\n'])
     result = client.get_many(['key1', 'key2'])
     tools.assert_equals(result, {'key1': 'value1', 'key2': 'value2'})
-
 
     client.sock = MockSocket(['VALUE key1 0 6\r\n',
                               'value1\r\n',
@@ -511,6 +509,7 @@ def test_serialization():
         'set key 0 0 20 noreply\r\n{"a": "b", "c": "d"}\r\n'
     ])
 
+
 def test_stats():
     client = Client(None)
     client.sock = MockSocket(['STAT fake_stats 1\r\n', 'END\r\n'])
@@ -520,6 +519,7 @@ def test_stats():
     ])
     tools.assert_equal(result, {'fake_stats': 1})
 
+
 def test_stats_with_args():
     client = Client(None)
     client.sock = MockSocket(['STAT fake_stats 1\r\n', 'END\r\n'])
@@ -528,6 +528,7 @@ def test_stats_with_args():
         'stats some_arg\r\n'
     ])
     tools.assert_equal(result, {'fake_stats': 1})
+
 
 def test_stats_conversions():
     client = Client(None)
@@ -562,6 +563,7 @@ def test_stats_conversions():
         'version': '1.4.14',
     }
     tools.assert_equal(result, expected)
+
 
 def test_socket_connect():
     server = ("example.com", 11211)


### PR DESCRIPTION
Hi!

I'd like to suggest this patch that lets users provide their own socket module to `Client`. 

The (obvious) use case is to let users use pymemcache with libraries such as gevent that require an alternate socket module, without needing to use monkey patching that can get ugly / loosely controlled from time to time (who likes globals anyway!).

I also took advantage of this new "feature" to add tests to the Client._connect, and the integration tests now run gevent if it's available.
