### PR TITLE
Add tox.ini for tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py26, py27, pypy, py33
+
+[testenv]
+commands =
+    python setup.py nosetests


### PR DESCRIPTION
This lets you use [tox](http://tox.testrun.org/) to test across Python versions:

```
marca@marca-mac:~/dev/git-repos/pymemcache$ tox
...
  py26: commands succeeded
  py27: commands succeeded
  pypy: commands succeeded
ERROR:   py33: commands failed
```
