### PR TITLE
byte/string management for py3 comptability

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     author = 'Charles Gordon',
     author_email = 'charles@pinterest.com',
     packages = find_packages(),
-    setup_requires = ['nose>=1.0'],
+    setup_requires = ['nose>=1.0', 'six'],
     description = 'A comprehensive, fast, pure Python memcached client',
     long_description = open('README.md').read(),
     license = 'Apache License 2.0',


### PR DESCRIPTION
- explicitly convert commands to bytes
- use bytes when interacting with the buffer read from socket.

I've only tested this change out manually on python 3.3.2 with a few memcached commands (`get/add/gets/cas`) and it works as expected. The full set of unit tests, however, doesn't run on python 3.3 - and I can look into that with another pull request. 
