### PR TITLE
Include _connect in ignore_exc try/except block

### DIFF
--- a/pymemcache/client.py
+++ b/pymemcache/client.py
@@ -685,13 +685,13 @@ class Client(object):
             raise MemcacheServerError(error)
 
     def _fetch_cmd(self, name, keys, expect_cas):
-        if not self.sock:
-            self._connect()
-
         checked_keys = dict((self.check_key(k), k) for k in keys)
         cmd = name + b' ' + b' '.join(checked_keys) + b'\r\n'
 
         try:
+            if not self.sock:
+                self._connect()
+
             self.sock.sendall(cmd)
 
             result = {}


### PR DESCRIPTION
The Best Practices section of the docstring explicitly suggests [using `ignore_exc` to make network errors look like misses](https://github.com/pinterest/pymemcache/blob/master/pymemcache/client.py#L63-L67) but if the client is new and not connected, [the `_connect` call](https://github.com/pinterest/pymemcache/blob/master/pymemcache/client.py#L63-L67) is not wrapped in a try/except block.

I assume this is an error in the client and not the docs.
