### PR TITLE
Make each client thread safe

### DIFF
--- a/pymemcache/client.py
+++ b/pymemcache/client.py
@@ -695,12 +695,12 @@ class Client(object):
             try:
                 buf = b''
                 sock.sendall(cmd)
-    
+
                 result = {}
                 while True:
                     buf, line = _readline(sock, buf)
                     self._raise_errors(line, name)
-    
+
                     if line == b'END':
                         return result
                     elif line.startswith(b'VALUE'):
@@ -715,10 +715,10 @@ class Client(object):
     
                         buf, value = _readvalue(sock, buf, int(size))
                         key = checked_keys[key]
-    
+
                         if self.deserializer:
                             value = self.deserializer(key, value, int(flags))
-    
+
                         if expect_cas:
                             result[key] = (value, cas)
                         else:
@@ -762,14 +762,14 @@ class Client(object):
         with self.socket_pool.get_and_release() as sock:
             try:
                 sock.sendall(cmd)
-    
+
                 if noreply:
                     return True
-    
+
                 buf = b''
                 buf, line = _readline(sock, buf)
                 self._raise_errors(line, name)
-    
+
                 if line in VALID_STORE_RESULTS[name]:
                     if line == b'STORED':
                         return True
@@ -789,10 +789,10 @@ class Client(object):
         with self.socket_pool.get_and_release() as sock:
             try:
                 sock.sendall(cmd)
-    
+
                 if noreply:
                     return
-    
+
                 _buf, line = _readline(sock, b'')
                 self._raise_errors(line, cmd_name)
                 return line

--- a/pymemcache/client.py
+++ b/pymemcache/client.py
@@ -231,7 +231,8 @@ class Client(object):
                  no_delay=False,
                  ignore_exc=False,
                  socket_module=socket,
-                 key_prefix=b''):
+                 key_prefix=b'',
+                 pool_max_size=None):
         """
         Constructor.
 
@@ -254,6 +255,8 @@ class Client(object):
             the standard library's socket module.
           key_prefix: Prefix of key. You can use this as namespace. Defaults
             to b''.
+          pool_max_size: Maximum number of sockets to create & maintain
+            in the per-client socket pool.
 
         Notes:
           The constructor does not make a connection to memcached. The first
@@ -273,7 +276,8 @@ class Client(object):
             raise TypeError("key_prefix should be bytes.")
         self.key_prefix = key_prefix
         self.socket_pool = pool.ObjectPool(
-            self._create_socket, before_remove=self._safe_close_socket)
+            self._create_socket, before_remove=self._safe_close_socket,
+            max_size=pool_max_size)
 
     def check_key(self, key):
         """Checks key and add key_prefix."""

--- a/pymemcache/client.py
+++ b/pymemcache/client.py
@@ -73,6 +73,8 @@ __author__ = "Charles Gordon"
 import socket
 import six
 
+from pymemcache import pool
+
 
 RECV_SIZE = 4096
 VALID_STORE_RESULTS = {
@@ -265,13 +267,13 @@ class Client(object):
         self.no_delay = no_delay
         self.ignore_exc = ignore_exc
         self.socket_module = socket_module
-        self.sock = None
-        self.buf = b''
         if isinstance(key_prefix, six.text_type):
             key_prefix = key_prefix.encode('ascii')
         if not isinstance(key_prefix, bytes):
             raise TypeError("key_prefix should be bytes.")
         self.key_prefix = key_prefix
+        self.socket_pool = pool.ObjectPool(
+            self._create_socket, before_remove=self._safe_close_socket)
 
     def check_key(self, key):
         """Checks key and add key_prefix."""
@@ -287,7 +289,14 @@ class Client(object):
             raise MemcacheIllegalInputError("Key is too long: %r" % (key,))
         return key
 
-    def _connect(self):
+    @staticmethod
+    def _safe_close_socket(sock):
+        try:
+            sock.close()
+        except Exception:
+            pass
+
+    def _create_socket(self):
         sock = self.socket_module.socket(self.socket_module.AF_INET,
                                          self.socket_module.SOCK_STREAM)
         sock.settimeout(self.connect_timeout)
@@ -296,18 +305,12 @@ class Client(object):
         if self.no_delay:
             sock.setsockopt(self.socket_module.IPPROTO_TCP,
                             self.socket_module.TCP_NODELAY, 1)
-        self.sock = sock
+        return sock
 
     def close(self):
-        """Close the connection to memcached, if it is open. The next call to a
-        method that requires a connection will re-open it."""
-        if self.sock is not None:
-            try:
-                self.sock.close()
-            except Exception:
-                pass
-        self.sock = None
-        self.buf = b''
+        """Close the connection(s) to memcached, if it is open. The next call
+        to a method that requires a connection will re-open it."""
+        self.socket_pool.clear()
 
     def set(self, key, value, expire=0, noreply=True):
         """
@@ -688,56 +691,51 @@ class Client(object):
         checked_keys = dict((self.check_key(k), k) for k in keys)
         cmd = name + b' ' + b' '.join(checked_keys) + b'\r\n'
 
-        try:
-            if not self.sock:
-                self._connect()
-
-            self.sock.sendall(cmd)
-
-            result = {}
-            while True:
-                self.buf, line = _readline(self.sock, self.buf)
-                self._raise_errors(line, name)
-
-                if line == b'END':
-                    return result
-                elif line.startswith(b'VALUE'):
-                    if expect_cas:
-                        _, key, flags, size, cas = line.split()
-                    else:
-                        try:
-                            _, key, flags, size = line.split()
-                        except Exception as e:
-                            raise ValueError("Unable to parse line %s: %s"
-                                             % (line, str(e)))
-
-                    self.buf, value = _readvalue(self.sock,
-                                                 self.buf,
-                                                 int(size))
-                    key = checked_keys[key]
-
-                    if self.deserializer:
-                        value = self.deserializer(key, value, int(flags))
-
-                    if expect_cas:
-                        result[key] = (value, cas)
-                    else:
+        with self.socket_pool.get_and_release() as sock:
+            try:
+                buf = b''
+                sock.sendall(cmd)
+    
+                result = {}
+                while True:
+                    buf, line = _readline(sock, buf)
+                    self._raise_errors(line, name)
+    
+                    if line == b'END':
+                        return result
+                    elif line.startswith(b'VALUE'):
+                        if expect_cas:
+                            _, key, flags, size, cas = line.split()
+                        else:
+                            try:
+                                _, key, flags, size = line.split()
+                            except Exception as e:
+                                raise ValueError("Unable to parse line %s: %s"
+                                                 % (line, str(e)))
+    
+                        buf, value = _readvalue(sock, buf, int(size))
+                        key = checked_keys[key]
+    
+                        if self.deserializer:
+                            value = self.deserializer(key, value, int(flags))
+    
+                        if expect_cas:
+                            result[key] = (value, cas)
+                        else:
+                            result[key] = value
+                    elif name == b'stats' and line.startswith(b'STAT'):
+                        _, key, value = line.split()
                         result[key] = value
-                elif name == b'stats' and line.startswith(b'STAT'):
-                    _, key, value = line.split()
-                    result[key] = value
-                else:
-                    raise MemcacheUnknownError(line[:32])
-        except Exception:
-            self.close()
-            if self.ignore_exc:
-                return {}
-            raise
+                    else:
+                        raise MemcacheUnknownError(line[:32])
+            except Exception:
+                self.socket_pool.destroy(sock)
+                if self.ignore_exc:
+                    return {}
+                raise
 
     def _store_cmd(self, name, key, expire, noreply, data, cas=None):
         key = self.check_key(key)
-        if not self.sock:
-            self._connect()
 
         if self.serializer:
             data, flags = self.serializer(key, data)
@@ -761,47 +759,46 @@ class Client(object):
                + b' ' + six.text_type(len(data)).encode('ascii') + extra
                + b'\r\n' + data + b'\r\n')
 
-        try:
-            self.sock.sendall(cmd)
-
-            if noreply:
-                return True
-
-            self.buf, line = _readline(self.sock, self.buf)
-            self._raise_errors(line, name)
-
-            if line in VALID_STORE_RESULTS[name]:
-                if line == b'STORED':
+        with self.socket_pool.get_and_release() as sock:
+            try:
+                sock.sendall(cmd)
+    
+                if noreply:
                     return True
-                if line == b'NOT_STORED':
-                    return False
-                if line == b'NOT_FOUND':
-                    return None
-                if line == b'EXISTS':
-                    return False
-            else:
-                raise MemcacheUnknownError(line[:32])
-        except Exception:
-            self.close()
-            raise
+    
+                buf = b''
+                buf, line = _readline(sock, buf)
+                self._raise_errors(line, name)
+    
+                if line in VALID_STORE_RESULTS[name]:
+                    if line == b'STORED':
+                        return True
+                    if line == b'NOT_STORED':
+                        return False
+                    if line == b'NOT_FOUND':
+                        return None
+                    if line == b'EXISTS':
+                        return False
+                else:
+                    raise MemcacheUnknownError(line[:32])
+            except Exception:
+                self.socket_pool.destroy(sock)
+                raise
 
     def _misc_cmd(self, cmd, cmd_name, noreply):
-        if not self.sock:
-            self._connect()
-
-        try:
-            self.sock.sendall(cmd)
-
-            if noreply:
-                return
-
-            _, line = _readline(self.sock, b'')
-            self._raise_errors(line, cmd_name)
-
-            return line
-        except Exception:
-            self.close()
-            raise
+        with self.socket_pool.get_and_release() as sock:
+            try:
+                sock.sendall(cmd)
+    
+                if noreply:
+                    return
+    
+                _buf, line = _readline(sock, b'')
+                self._raise_errors(line, cmd_name)
+                return line
+            except Exception:
+                self.socket_pool.destroy(sock)
+                raise
 
     def __setitem__(self, key, value):
         self.set(key, value, noreply=True)

--- a/pymemcache/pool.py
+++ b/pymemcache/pool.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import six
+
 import contextlib
 import threading
 
@@ -24,7 +26,7 @@ class ObjectPool(object):
         self._lock = threading.Lock()
         self._before_remove = before_remove
         max_size = max_size or 2 ** 31
-        if not isinstance(max_size, (int, long)) or max_size < 0:
+        if not isinstance(max_size, six.integer_types) or max_size < 0:
             raise ValueError('"max_size" must be a positive integer')
         self.max_size = max_size
 

--- a/pymemcache/pool.py
+++ b/pymemcache/pool.py
@@ -44,10 +44,7 @@ class ObjectPool(object):
         try:
             yield obj
         finally:
-            try:
-                self.release(obj)
-            except ValueError:
-                pass
+            self.release(obj)
 
     def get(self):
         with self._lock:

--- a/pymemcache/pool.py
+++ b/pymemcache/pool.py
@@ -61,17 +61,25 @@ class ObjectPool(object):
                 self._used_objs.append(self._free_objs.pop())
                 return self._used_objs[-1]
 
-    def destroy(self, obj):
+    def destroy(self, obj, silent=True):
         with self._lock:
-            idx = self._used_objs.index(obj)
-            if self._before_remove is not None:
-                self._before_remove(obj)
-            self._used_objs.pop(idx)
+            try:
+                idx = self._used_objs.index(obj)
+                if self._before_remove is not None:
+                    self._before_remove(obj)
+                self._used_objs.pop(idx)
+            except (ValueError, IndexError):
+                if not silent:
+                    raise
 
-    def release(self, obj):
+    def release(self, obj, silent=True):
         with self._lock:
-            self._used_objs.remove(obj)
-            self._free_objs.append(obj)
+            try:
+                self._used_objs.remove(obj)
+                self._free_objs.append(obj)
+            except (ValueError, IndexError):
+                if not silent:
+                    raise
 
     def clear(self):
         with self._lock:

--- a/pymemcache/pool.py
+++ b/pymemcache/pool.py
@@ -65,19 +65,21 @@ class ObjectPool(object):
         with self._lock:
             try:
                 idx = self._used_objs.index(obj)
-                if self._before_remove is not None:
-                    self._before_remove(obj)
-                self._used_objs.pop(idx)
-            except (ValueError, IndexError):
+            except ValueError:
                 if not silent:
                     raise
+                else:
+                    return
+            if self._before_remove is not None:
+                self._before_remove(obj)
+            self._used_objs.pop(idx)
 
     def release(self, obj, silent=True):
         with self._lock:
             try:
                 self._used_objs.remove(obj)
                 self._free_objs.append(obj)
-            except (ValueError, IndexError):
+            except ValueError:
                 if not silent:
                     raise
 

--- a/pymemcache/pool.py
+++ b/pymemcache/pool.py
@@ -1,0 +1,80 @@
+# Copyright 2015 Yahoo.com
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+import threading
+
+
+class ObjectPool(object):
+    def __init__(self, obj_creator, before_remove=None, max_size=None):
+        self._used_objs = []
+        self._free_objs = []
+        self._obj_creator = obj_creator
+        self._lock = threading.Lock()
+        self._before_remove = before_remove
+        self.max_size = max_size or 2 ** 31
+
+    @property
+    def used(self):
+        return self._used_objs[:]
+
+    @property
+    def free(self):
+        return self._free_objs[:]
+
+    @contextlib.contextmanager
+    def get_and_release(self):
+        obj = self.get()
+        try:
+            yield obj
+        finally:
+            try:
+                self.release(obj)
+            except (ValueError, IndexError):
+                pass
+
+    def get(self):
+        with self._lock:
+            if not self._free_objs:
+                curr_count = len(self._used_objs) + len(self._free_objs)
+                if curr_count >= self.max_size:
+                    raise RuntimeError("Too many objects")
+                self._used_objs.append(self._obj_creator())
+                return self._used_objs[-1]
+            else:
+                self._used_objs.append(self._free_objs.pop())
+                return self._used_objs[-1]
+
+    def destroy(self, obj):
+        with self._lock:
+            idx = self._used_objs.index(obj)
+            if self._before_remove is not None:
+                self._before_remove(obj)
+            self._used_objs.pop(idx)
+
+    def release(self, obj):
+        with self._lock:
+            self._used_objs.remove(obj)
+            self._free_objs.append(obj)
+
+    def clear(self):
+        with self._lock:
+            if self._before_remove is not None:
+                while self._used_objs:
+                    self._before_remove(self._used_objs.pop())
+                while self._free_objs:
+                    self._before_remove(self._free_objs.pop())
+            else:
+                self._free_objs = []
+                self._used_objs = []

--- a/pymemcache/pool.py
+++ b/pymemcache/pool.py
@@ -23,7 +23,10 @@ class ObjectPool(object):
         self._obj_creator = obj_creator
         self._lock = threading.Lock()
         self._before_remove = before_remove
-        self.max_size = max_size or 2 ** 31
+        max_size = max_size or 2 ** 31
+        if not isinstance(max_size, (int, long)) or max_size < 0:
+            raise ValueError('"max_size" must be a positive integer')
+        self.max_size = max_size
 
     @property
     def used(self):

--- a/pymemcache/pool.py
+++ b/pymemcache/pool.py
@@ -46,7 +46,7 @@ class ObjectPool(object):
         finally:
             try:
                 self.release(obj)
-            except (ValueError, IndexError):
+            except ValueError:
                 pass
 
     def get(self):


### PR DESCRIPTION
- Add a object pool that can create sockets in a thread
  safe manner (and release and destroy them as/when needed).
- Avoid using a client 'buffer' and use a per-function/method
  buffer instead to avoid having multiple threads writing into
  the same buffer.

Fixes issue #34 