### PR TITLE
Remove instance local buffer

### DIFF
--- a/pymemcache/client.py
+++ b/pymemcache/client.py
@@ -266,7 +266,6 @@ class Client(object):
         self.ignore_exc = ignore_exc
         self.socket_module = socket_module
         self.sock = None
-        self.buf = b''
         if isinstance(key_prefix, six.text_type):
             key_prefix = key_prefix.encode('ascii')
         if not isinstance(key_prefix, bytes):
@@ -307,7 +306,6 @@ class Client(object):
             except Exception:
                 pass
         self.sock = None
-        self.buf = b''
 
     def set(self, key, value, expire=0, noreply=True):
         """
@@ -694,9 +692,10 @@ class Client(object):
 
             self.sock.sendall(cmd)
 
+            buf = b''
             result = {}
             while True:
-                self.buf, line = _readline(self.sock, self.buf)
+                buf, line = _readline(self.sock, buf)
                 self._raise_errors(line, name)
 
                 if line == b'END':
@@ -711,9 +710,7 @@ class Client(object):
                             raise ValueError("Unable to parse line %s: %s"
                                              % (line, str(e)))
 
-                    self.buf, value = _readvalue(self.sock,
-                                                 self.buf,
-                                                 int(size))
+                    buf, value = _readvalue(self.sock, buf, int(size))
                     key = checked_keys[key]
 
                     if self.deserializer:
@@ -767,7 +764,8 @@ class Client(object):
             if noreply:
                 return True
 
-            self.buf, line = _readline(self.sock, self.buf)
+            buf = b''
+            buf, line = _readline(self.sock, buf)
             self._raise_errors(line, name)
 
             if line in VALID_STORE_RESULTS[name]:

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -329,7 +329,6 @@ class TestClient(ClientTestMixin, unittest.TestCase):
 
         tools.assert_raises(Exception, _delete)
         tools.assert_equal(client.sock, None)
-        tools.assert_equal(client.buf, b'')
 
     def test_flush_all(self):
         client = self.Client(None)
@@ -346,7 +345,6 @@ class TestClient(ClientTestMixin, unittest.TestCase):
 
         tools.assert_raises(Exception, _incr)
         tools.assert_equal(client.sock, None)
-        tools.assert_equal(client.buf, b'')
 
     def test_get_error(self):
         client = self.Client(None)
@@ -415,7 +413,6 @@ class TestClient(ClientTestMixin, unittest.TestCase):
         result = client.quit()
         tools.assert_equal(result, None)
         tools.assert_equal(client.sock, None)
-        tools.assert_equal(client.buf, b'')
 
     def test_replace_stored(self):
         client = self.Client(None)
@@ -466,7 +463,6 @@ class TestClient(ClientTestMixin, unittest.TestCase):
 
         tools.assert_raises(Exception, _set)
         tools.assert_equal(client.sock, None)
-        tools.assert_equal(client.buf, b'')
 
     def test_set_client_error(self):
         client = self.Client(None)
@@ -513,7 +509,6 @@ class TestClient(ClientTestMixin, unittest.TestCase):
 
         tools.assert_raises(Exception, _set)
         tools.assert_equal(client.sock, None)
-        tools.assert_equal(client.buf, b'')
 
     def test_stats(self):
         client = self.Client(None)


### PR DESCRIPTION
It doesn't seem needed to have instance local-side effects
especially around a shared buffer (having it exists makes
thread-safety and/or thread-safe clients that much harder to
achieve).