### PR TITLE
Allow the pool lock to be specialized

### DIFF
--- a/pymemcache/client.py
+++ b/pymemcache/client.py
@@ -826,13 +826,14 @@ class Client(object):
 class PooledClient(object):
     """A thread-safe pool of clients (with the same client api).
 
-    :param max_pool_size: maximum pool size to use (going about this
-                          amount triggers a runtime error), by default this
-                          is 2147483648L when not provided.
-    :param lock_generator: a callback/type that takes no arguments that will
-                           be called to create a lock or sempahore that can
-                           protect the pool from concurrent
-                           access (for example a eventlet lock or semaphore)
+    Args:
+      max_pool_size: maximum pool size to use (going about this amount
+                     triggers a runtime error), by default this is 2147483648L
+                     when not provided (or none).
+      lock_generator: a callback/type that takes no arguments that will
+                      be called to create a lock or sempahore that can
+                      protect the pool from concurrent access (for example a
+                      eventlet lock or semaphore could be used instead)
 
     Further arguments are interpreted as for :py:class:`.Client` constructor.
     """

--- a/pymemcache/client.py
+++ b/pymemcache/client.py
@@ -836,7 +836,10 @@ class PooledClient(object):
                  ignore_exc=False,
                  socket_module=socket,
                  key_prefix=b'',
-                 max_pool_size=None):
+                 max_pool_size=None,
+                 # Allow this to be a different style of lock (eventlet
+                 # lock/semaphore for example, that works with greenthreads).
+                 lock_generator=None):
         self.server = server
         self.serializer = serializer
         self.deserializer = deserializer
@@ -853,7 +856,8 @@ class PooledClient(object):
         self.client_pool = pool.ObjectPool(
             self._create_client,
             after_remove=lambda client: client.close(),
-            max_size=max_pool_size)
+            max_size=max_pool_size,
+            lock_generator=lock_generator)
 
     def check_key(self, key):
         """Checks key and add key_prefix."""

--- a/pymemcache/client.py
+++ b/pymemcache/client.py
@@ -824,7 +824,18 @@ class Client(object):
 
 
 class PooledClient(object):
-    """A thread-safe pool of clients (with the same client api)."""
+    """A thread-safe pool of clients (with the same client api).
+
+    :param max_pool_size: maximum pool size to use (going about this
+                          amount triggers a runtime error), by default this
+                          is 2147483648L when not provided.
+    :param lock_generator: a callback/type that takes no arguments that will
+                           be called to create a lock or sempahore that can
+                           protect the pool from concurrent
+                           access (for example a eventlet lock or semaphore)
+
+    Further arguments are interpreted as for :py:class:`.Client` constructor.
+    """
 
     def __init__(self,
                  server,

--- a/pymemcache/client.py
+++ b/pymemcache/client.py
@@ -848,8 +848,6 @@ class PooledClient(object):
                  socket_module=socket,
                  key_prefix=b'',
                  max_pool_size=None,
-                 # Allow this to be a different style of lock (eventlet
-                 # lock/semaphore for example, that works with greenthreads).
                  lock_generator=None):
         self.server = server
         self.serializer = serializer

--- a/pymemcache/pool.py
+++ b/pymemcache/pool.py
@@ -24,11 +24,15 @@ class ObjectPool(object):
     """A pool of objects that release/creates/destroys as needed."""
 
     def __init__(self, obj_creator,
-                 after_remove=None, max_size=None):
+                 after_remove=None, max_size=None,
+                 lock_generator=None):
         self._used_objs = collections.deque()
         self._free_objs = collections.deque()
         self._obj_creator = obj_creator
-        self._lock = threading.Lock()
+        if lock_generator is None:
+            self._lock = threading.Lock()
+        else:
+            self._lock = lock_generator()
         self._after_remove = after_remove
         max_size = max_size or 2 ** 31
         if not isinstance(max_size, six.integer_types) or max_size < 0:


### PR DESCRIPTION
It can be quite useful to allow the lock that the pool
uses to be specified to be something other than the default
threading lock class/type. This can be especially useful when
eventlet (or gevent or other) are used which have there own
special lock type that connects into there event-loop.