### PR TITLE
Multi methods

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -389,6 +389,8 @@ class Client(object):
 
         return self._fetch_cmd(b'get', keys, False)
 
+    get_multi = get_many
+
     def gets(self, key):
         """
         The memcached "gets" command for one key, as a convenience.
@@ -851,6 +853,8 @@ class PooledClient(object):
                     return {}
                 else:
                     raise
+
+    get_multi = get_many
 
     def gets(self, key):
         with self.client_pool.get_and_release(destroy_on_fail=True) as client:

--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -271,6 +271,8 @@ class Client(object):
             self.set(key, value, expire, noreply)
         return True
 
+    set_multi = set_many
+
     def add(self, key, value, expire=0, noreply=True):
         """
         The memcached "add" command.
@@ -810,6 +812,8 @@ class PooledClient(object):
     def set_many(self, values, expire=0, noreply=True):
         with self.client_pool.get_and_release(destroy_on_fail=True) as client:
             return client.set_many(values, expire=expire, noreply=noreply)
+
+    set_multi = set_many
 
     def replace(self, key, value, expire=0, noreply=True):
         with self.client_pool.get_and_release(destroy_on_fail=True) as client:

--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -463,6 +463,8 @@ class Client(object):
 
         return True
 
+    delete_multi = delete_many
+
     def incr(self, key, value, noreply=False):
         """
         The memcached "incr" command.
@@ -883,6 +885,8 @@ class PooledClient(object):
     def delete_many(self, keys, noreply=True):
         with self.client_pool.get_and_release(destroy_on_fail=True) as client:
             return client.delete_many(keys, noreply=noreply)
+
+    delete_multi = delete_many
 
     def add(self, key, value, expire=0, noreply=True):
         with self.client_pool.get_and_release(destroy_on_fail=True) as client:

--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -296,6 +296,11 @@ class HashClient(object):
     def delete(self, key, *args, **kwargs):
         return self._run_cmd('delete', key, False, *args, **kwargs)
 
+    def delete_many(self, keys, *args, **kwargs):
+        for key in keys:
+            self._run_cmd('delete', key, False, *args, **kwargs)
+        return True
+
     def cas(self, key, *args, **kwargs):
         return self._run_cmd('cas', key, False, *args, **kwargs)
 

--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -254,6 +254,8 @@ class HashClient(object):
 
         return all(end)
 
+    set_multi = set_many
+
     def get_many(self, keys, *args, **kwargs):
         client_batches = {}
         for key in keys:

--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -301,6 +301,8 @@ class HashClient(object):
             self._run_cmd('delete', key, False, *args, **kwargs)
         return True
 
+    delete_multi = delete_many
+
     def cas(self, key, *args, **kwargs):
         return self._run_cmd('cas', key, False, *args, **kwargs)
 

--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -279,6 +279,8 @@ class HashClient(object):
 
         return end
 
+    get_multi = get_many
+
     def gets(self, key, *args, **kwargs):
         return self._run_cmd('gets', key, None, *args, **kwargs)
 

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -148,6 +148,11 @@ class ClientTestMixin(object):
         result = client.get_many([b'key1', b'key2'])
         assert result == {}
 
+    def test_get_multi_none_found(self):
+        client = self.make_client([b'END\r\n'])
+        result = client.get_multi([b'key1', b'key2'])
+        assert result == {}
+
     def test_get_many_some_found(self):
         client = self.make_client([
             b'STORED\r\n',

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -111,6 +111,12 @@ class ClientTestMixin(object):
         result = client.set_many({b'key': b'value'}, noreply=False)
         assert result is True
 
+    def test_set_multi_success(self):
+        # Should just map to set_many
+        client = self.make_client([b'STORED\r\n'])
+        result = client.set_multi({b'key': b'value'}, noreply=False)
+        assert result is True
+
     def test_add_stored(self):
         client = self.make_client([b'STORED\r', b'\n'])
         result = client.add(b'key', b'value', noreply=False)

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -225,6 +225,16 @@ class ClientTestMixin(object):
         result = client.delete_many([b'key', b'key2'], noreply=False)
         assert result is True
 
+    def test_delete_multi_some_found(self):
+        client = self.make_client([
+            b'STORED\r\n',
+            b'DELETED\r\n',
+            b'NOT_FOUND\r\n'
+        ])
+        result = client.add(b'key', b'value', noreply=False)
+        result = client.delete_multi([b'key', b'key2'], noreply=False)
+        assert result is True
+
     def test_incr_not_found(self):
         client = self.make_client([b'NOT_FOUND\r\n'])
         result = client.incr(b'key', 1, noreply=False)

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -199,6 +199,32 @@ class ClientTestMixin(object):
         result = client.delete(b'key', noreply=True)
         assert result is True
 
+    def test_delete_many_no_keys(self):
+        client = self.make_client([])
+        result = client.delete_many([], noreply=False)
+        assert result is True
+
+    def test_delete_many_none_found(self):
+        client = self.make_client([b'NOT_FOUND\r\n'])
+        result = client.delete_many([b'key'], noreply=False)
+        assert result is True
+
+    def test_delete_many_found(self):
+        client = self.make_client([b'STORED\r', b'\n', b'DELETED\r\n'])
+        result = client.add(b'key', b'value', noreply=False)
+        result = client.delete_many([b'key'], noreply=False)
+        assert result is True
+
+    def test_delete_many_some_found(self):
+        client = self.make_client([
+            b'STORED\r\n',
+            b'DELETED\r\n',
+            b'NOT_FOUND\r\n'
+        ])
+        result = client.add(b'key', b'value', noreply=False)
+        result = client.delete_many([b'key', b'key2'], noreply=False)
+        assert result is True
+
     def test_incr_not_found(self):
         client = self.make_client([b'NOT_FOUND\r\n'])
         result = client.incr(b'key', 1, noreply=False)

--- a/pymemcache/test/utils.py
+++ b/pymemcache/test/utils.py
@@ -84,6 +84,8 @@ class MockMemcacheClient(object):
             self.set(key, value, expire, noreply)
         return True
 
+    set_multi = set_many
+
     def incr(self, key, value, noreply=False):
         current = self.get(key)
         present = current is not None

--- a/pymemcache/test/utils.py
+++ b/pymemcache/test/utils.py
@@ -115,6 +115,11 @@ class MockMemcacheClient(object):
         present = current is not None
         return noreply or present
 
+    def delete_many(self, keys, noreply=True):
+        for key in keys:
+            self.delete(key, noreply)
+        return True
+
     def stats(self):
         # I make no claim that these values make any sense, but the format
         # of the output is the same as for pymemcache.client.Client.stats()

--- a/pymemcache/test/utils.py
+++ b/pymemcache/test/utils.py
@@ -120,6 +120,8 @@ class MockMemcacheClient(object):
             self.delete(key, noreply)
         return True
 
+    delete_multi = delete_many
+
     def stats(self):
         # I make no claim that these values make any sense, but the format
         # of the output is the same as for pymemcache.client.Client.stats()

--- a/pymemcache/test/utils.py
+++ b/pymemcache/test/utils.py
@@ -63,6 +63,8 @@ class MockMemcacheClient(object):
                 out[key] = value
         return out
 
+    get_multi = get_many
+
     def set(self, key, value, expire=0, noreply=True):
         if isinstance(key, six.text_type):
             raise MemcacheIllegalInputError(key)


### PR DESCRIPTION
Fixes #58 . Basic `x = y` renaming.

Also `delete_many` was missing on some of the Client classes, so I added it and tests for it.