### PR TITLE
make the hasher class pluggable in HashClient

### DIFF
--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -15,7 +15,7 @@ class HashClient(object):
     def __init__(
         self,
         servers,
-        hasher=None,
+        hasher=RendezvousHash,
         serializer=None,
         deserializer=None,
         connect_timeout=None,
@@ -70,8 +70,7 @@ class HashClient(object):
         self._dead_clients = {}
         self._last_dead_check_time = time.time()
 
-        if hasher is None:
-            self.hasher = RendezvousHash()
+        self.hasher = hasher()
 
         self.default_kwargs = {
             'connect_timeout': connect_timeout,


### PR DESCRIPTION
I was doing some benchmarking and I needed this patch to be able to plug in ewdurbin/clandestined-python as the hash implementation.

In passing, there's a separate issue where pymemcache calls the relevant method `get_node`, but clandestined-python calls it `find_node`.

Thanks for your time.