### PR TITLE
hashclient ignores exceptions when no servers are found

### DIFF
--- a/pymemcache/test/test_client_hash.py
+++ b/pymemcache/test/test_client_hash.py
@@ -119,4 +119,62 @@ class TestHashClient(ClientTestMixin, unittest.TestCase):
         client.set(b'key3', b'value2', noreply=False)
         result = client.get_many([b'key1', b'key3'])
         assert result == {}
+
+    def test_no_servers_left(self):
+        from pymemcache.client.hash import HashClient
+        client = HashClient(
+            [], use_pooling=True,
+            ignore_exc=True,
+            timeout=1, connect_timeout=1
+        )
+
+        hashed_client = client._get_client('foo')
+        assert hashed_client is None
+
+    def test_no_servers_left_raise_exception(self):
+        from pymemcache.client.hash import HashClient
+        client = HashClient(
+            [], use_pooling=True,
+            ignore_exc=False,
+            timeout=1, connect_timeout=1
+        )
+
+        with pytest.raises(Exception) as e:
+            client._get_client('foo')
+
+        assert str(e.value) == 'All servers seem to be down right now'
+
+    def test_no_servers_left_with_commands(self):
+        from pymemcache.client.hash import HashClient
+        client = HashClient(
+            [], use_pooling=True,
+            ignore_exc=True,
+            timeout=1, connect_timeout=1
+        )
+
+        result = client.get('foo')
+        assert result is False
+
+    def test_no_servers_left_with_set_many(self):
+        from pymemcache.client.hash import HashClient
+        client = HashClient(
+            [], use_pooling=True,
+            ignore_exc=True,
+            timeout=1, connect_timeout=1
+        )
+
+        result = client.set_many({'foo': 'bar'})
+        assert result is False
+
+    def test_no_servers_left_with_get_many(self):
+        from pymemcache.client.hash import HashClient
+        client = HashClient(
+            [], use_pooling=True,
+            ignore_exc=True,
+            timeout=1, connect_timeout=1
+        )
+
+        result = client.get_many(['foo', 'bar'])
+        assert result == {'foo': False, 'bar': False}
+
     # TODO: Test failover logic


### PR DESCRIPTION
This fixes the hashclient when `ignore_exc` is set to `True`.   I will make a separate PR on top of this that will get no servers found put into the retry cycle.  So if all servers are down but we haven't waited our defined time it wont blow up either.  Just need to think about that use case a little more :)