### PR TITLE
Add myself to credits.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,3 +108,4 @@ Credits
 * `Joshua Harlow <http://github.com/harlowja>`_
 * `John Anderson <http://github.com/sontek>`_
 * `Adam Chainz <http://github.com/adamchainz>`_
+* `Ernest W. Durbin III <https://github.com/ewdurbin>`_


### PR DESCRIPTION
with the significant amount of `python-clandestined` source code copied into the `HashClient`, I would appreciate accreditation somewhere high-level than in the depths of source code.