### PR TITLE
Fixed bugs caused by setting retry attempts to 0 on HashClient

### DIFF
--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -185,13 +185,13 @@ class HashClient(object):
             # dead immediately
             elif (
                 client.server not in self._failed_clients and
-                self.retry_attempts < 0
+                self.retry_attempts <= 0
             ):
                 self._failed_clients[client.server] = {
                     'failed_time': time.time(),
                     'attempts': 0,
                 }
-                logger.debug("marking server as dead %s" % client.server)
+                logger.debug("marking server as dead %s", client.server)
                 self.remove_server(*client.server)
             # This client has failed previously, we need to update the metadata
             # to reflect that we have attempted it again

--- a/pymemcache/test/test_client_hash.py
+++ b/pymemcache/test/test_client_hash.py
@@ -7,6 +7,7 @@ from .test_client import ClientTestMixin, MockSocket
 import unittest
 import pytest
 import mock
+import socket
 
 
 class TestHashClient(ClientTestMixin, unittest.TestCase):
@@ -143,6 +144,17 @@ class TestHashClient(ClientTestMixin, unittest.TestCase):
             client._get_client('foo')
 
         assert str(e.value) == 'All servers seem to be down right now'
+
+    def test_unavailable_servers_zero_retry_raise_exception(self):
+        from pymemcache.client.hash import HashClient
+        client = HashClient(
+            [('example.com', 11211)], use_pooling=True,
+            ignore_exc=False,
+            retry_attempts=0, timeout=1, connect_timeout=1
+        )
+
+        with pytest.raises(socket.error) as e:
+            client.get('foo')
 
     def test_no_servers_left_with_commands(self):
         from pymemcache.client.hash import HashClient


### PR DESCRIPTION
This pull fixes 2 small issues.

The first is an exception thrown when `retry_attempts` to 0 instead of -1 to disable it. It would throw a key error due to `self._failed_clients` not being populated.

The second issue is an exception regarding the use of % while creating output log and `client.server` being a tuple instead of a string.

Included testcase fails on current master and succeeds on this branch.