### PR TITLE
Implemented VERSION command in Client and PooledClient

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -598,6 +598,21 @@ class Client(object):
 
         return result
 
+    def version(self):
+        """
+        The memcached "version" command.
+
+        Returns:
+            A string of the memcached version.
+        """
+        cmd = b"version\r\n"
+        result = self._misc_cmd(cmd, b'version', False)
+
+        if not result.startswith(b'VERSION '):
+            raise MemcacheUnknownError("Received unexpected response: %s" % (result, ))
+
+        return result[8:]
+
     def flush_all(self, delay=0, noreply=None):
         """
         The memcached "flush_all" command.
@@ -948,6 +963,10 @@ class PooledClient(object):
                     return {}
                 else:
                     raise
+
+    def version(self):
+        with self.client_pool.get_and_release(destroy_on_fail=True) as client:
+            return client.version()
 
     def flush_all(self, delay=0, noreply=True):
         with self.client_pool.get_and_release(destroy_on_fail=True) as client:

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -652,6 +652,16 @@ class TestClient(ClientTestMixin, unittest.TestCase):
         result = client.flush_all()
         assert result is True
 
+    def test_version_success(self):
+        client = self.make_client([b'VERSION 1.2.3\r\n'], default_noreply=False)
+        result = client.version()
+        assert result == b'1.2.3'
+
+    def test_version_exception(self):
+        client = self.make_client([b'INVALID DATA\r\n'], default_noreply=False)
+        with pytest.raises(MemcacheUnknownError):
+            result = client.version()
+
 
 @pytest.mark.unit()
 class TestClientSocketConnect(unittest.TestCase):


### PR DESCRIPTION
As the title says, added the version command, although for the wrong reasons. 
We found it useful as a "NoOp" command during health checks.
Others may find it useful to actually get the server version.