### PR TITLE
Handle stats not conforming to the triplet format

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -699,8 +699,8 @@ class Client(object):
                     else:
                         result[key] = value
                 elif name == b'stats' and line.startswith(b'STAT'):
-                    _, key, value = line.split()
-                    result[key] = value
+                    key_value = line.split()
+                    result[key_value[1]] = key_value[2]
                 else:
                     raise MemcacheUnknownError(line[:32])
         except Exception:


### PR DESCRIPTION
Addresses issue #92

In Ubuntu's (14.04) version of memecached packaged with the OS the
version STAT line contains a fourth value due to a space. This breaks
the expected triplet pattern and incorrectly caused an exception.