### PR TITLE
Fixed stats evictions value conversion

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -53,7 +53,6 @@ STAT_TYPES = {
 
     # Settings stats
     b'inter': six.binary_type,
-    b'evictions': lambda value: value == b'on',
     b'growth_factor': float,
     b'stat_key_prefix': six.binary_type,
     b'umask': lambda value: int(value, 8),

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -546,6 +546,7 @@ class TestClient(ClientTestMixin, unittest.TestCase):
             # Most stats are converted to int
             b'STAT cmd_get 2519\r\n',
             b'STAT cmd_set 3099\r\n',
+            b'STAT evictions 939\r\n',
 
             # Unless they can't be, they remain str
             b'STAT libevent 2.0.19-stable\r\n',
@@ -565,6 +566,7 @@ class TestClient(ClientTestMixin, unittest.TestCase):
         expected = {
             b'cmd_get': 2519,
             b'cmd_set': 3099,
+            b'evictions': 939,
             b'libevent': b'2.0.19-stable',
             b'hash_is_expanding': False,
             b'rusage_user': 0.609165,


### PR DESCRIPTION
Addresses issue #94 

Fixed evictions value conversion in base.py.  
- evictions stat value was incorrectly being compared to “b’on’” previously, which resulted in a boolean. The fix makes the conversion default to int, which is in line with other numeric stats values.

Augmented test_stats_conversions() test case in test_client.py to test evictions value conversion