### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ pymemcache
     :target: https://pypi.python.org/pypi/pymemcache
 
 .. image:: https://readthedocs.org/projects/pymemcache/badge/?version=master
-        :target: http://pymemcache.readthedocs.org/en/latest/
+        :target: https://pymemcache.readthedocs.io/en/latest/
         :alt: Master Documentation Status
 
 A comprehensive, fast, pure-Python memcached client.
@@ -41,7 +41,7 @@ For development, clone from github and run the tests with:
 Usage
 =====
 
-See the documentation here: http://pymemcache.readthedocs.org/en/latest/
+See the documentation here: https://pymemcache.readthedocs.io/en/latest/
 
 Comparison with Other Libraries
 ===============================


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.