### PR TITLE
Syntax and build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,11 @@ develop-eggs
 .installed.cfg
 build
 dist
+.cache
 
 # Installer logs
 pip-log.txt
+env/
 
 # Unit test / coverage reports
 .coverage

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ env/
 coverage.xml
 \#*\#
 docs/_build
+docs/apidoc/pymemcache.test.rst

--- a/pymemcache/__init__.py
+++ b/pymemcache/__init__.py
@@ -1,1 +1,2 @@
 __version__ = '1.3.5'
+__author__ = "Charles Gordon"

--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -11,9 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-__author__ = "Charles Gordon"
-
 import errno
 import socket
 import six
@@ -608,7 +605,8 @@ class Client(object):
         result = self._misc_cmd(cmd, b'version', False)
 
         if not result.startswith(b'VERSION '):
-            raise MemcacheUnknownError("Received unexpected response: %s" % (result, ))
+            raise MemcacheUnknownError(
+                    "Received unexpected response: %s" % (result, ))
 
         return result[8:]
 
@@ -730,10 +728,11 @@ class Client(object):
         if noreply:
             extra += b' noreply'
 
-        cmd = (name + b' ' + key + b' ' + six.text_type(flags).encode('ascii')
-               + b' ' + six.text_type(expire).encode('ascii')
-               + b' ' + six.text_type(len(data)).encode('ascii') + extra
-               + b'\r\n' + data + b'\r\n')
+        cmd = (name + b' ' + key + b' ' +
+               six.text_type(flags).encode('ascii') +
+               b' ' + six.text_type(expire).encode('ascii') +
+               b' ' + six.text_type(len(data)).encode('ascii') + extra +
+               b'\r\n' + data + b'\r\n')
 
         try:
             self.sock.sendall(cmd)

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -655,14 +655,15 @@ class TestClient(ClientTestMixin, unittest.TestCase):
         assert result is True
 
     def test_version_success(self):
-        client = self.make_client([b'VERSION 1.2.3\r\n'], default_noreply=False)
+        client = self.make_client([b'VERSION 1.2.3\r\n'],
+                                  default_noreply=False)
         result = client.version()
         assert result == b'1.2.3'
 
     def test_version_exception(self):
         client = self.make_client([b'INVALID DATA\r\n'], default_noreply=False)
         with pytest.raises(MemcacheUnknownError):
-            result = client.version()
+            client.version()
 
 
 @pytest.mark.unit()

--- a/pymemcache/test/test_client_hash.py
+++ b/pymemcache/test/test_client_hash.py
@@ -153,7 +153,7 @@ class TestHashClient(ClientTestMixin, unittest.TestCase):
             retry_attempts=0, timeout=1, connect_timeout=1
         )
 
-        with pytest.raises(socket.error) as e:
+        with pytest.raises(socket.error):
             client.get('foo')
 
     def test_no_servers_left_with_commands(self):

--- a/tox.ini
+++ b/tox.ini
@@ -5,12 +5,12 @@ envlist = py26, py27, pypy, pypy3, py33, py34, docs, flake8
 commands =
     pip install -r test-requirements.txt
     pip install -e .
-    py.test {posargs}
+    py.test {posargs:pymemcache/test/}
 
 [testenv:flake8]
 commands =
-	pip install flake8
-	flake8 .
+    pip install flake8
+    flake8 pymemcache/
 
 [testenv:docs]
 commands =


### PR DESCRIPTION
Running `tox` left the project with some syntax and build errors. This cleans it up a little so that cloning and running `tox` should run fine