### PR TITLE
Added default parameter support for "get" and "gets" methods in Client

### DIFF
--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -134,6 +134,11 @@ class ClientTestMixin(object):
         result = client.get(b'key')
         assert result is None
 
+    def test_get_not_found_default(self):
+        client = self.make_client([b'END\r\n'])
+        result = client.get(b'key', default='foobar')
+        assert result is 'foobar'
+
     def test_get_found(self):
         client = self.make_client([
             b'STORED\r\n',
@@ -401,6 +406,11 @@ class TestClient(ClientTestMixin, unittest.TestCase):
         client = self.make_client([b'END\r\n'])
         result = client.gets(b'key')
         assert result == (None, None)
+
+    def test_gets_not_found_defaults(self):
+        client = self.make_client([b'END\r\n'])
+        result = client.gets(b'key', default='foo', cas_default='bar')
+        assert result == ('foo', 'bar')
 
     def test_gets_found(self):
         client = self.make_client([b'VALUE key 0 5 10\r\nvalue\r\nEND\r\n'])

--- a/pymemcache/test/utils.py
+++ b/pymemcache/test/utils.py
@@ -40,17 +40,17 @@ class MockMemcacheClient(object):
         self.no_delay = no_delay
         self.ignore_exc = ignore_exc
 
-    def get(self, key):
+    def get(self, key, default=None):
         if isinstance(key, six.text_type):
             raise MemcacheIllegalInputError(key)
 
         if key not in self._contents:
-            return None
+            return default
 
         expire, value, was_serialized = self._contents[key]
         if expire and expire < time.time():
             del self._contents[key]
-            return None
+            return default
 
         if self.deserializer:
             return self.deserializer(key, value, 2 if was_serialized else 1)


### PR DESCRIPTION
I thought it would be a nice feature to be able to do:

```python
foo = client.get('foo', default=b'bar').decode()
```

instead of:

```python
foo = client.get('foo')
if foo is None:
    foo = b'foo'
foo.decode()
```