### PR TITLE
Lint on Python 3 too

### DIFF
--- a/pymemcache/serde.py
+++ b/pymemcache/serde.py
@@ -14,11 +14,7 @@
 
 import logging
 import pickle
-
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from StringIO import StringIO
+from six.moves import cStringIO as StringIO
 
 try:
     long_type = long  # noqa

--- a/pymemcache/serde.py
+++ b/pymemcache/serde.py
@@ -14,7 +14,7 @@
 
 import logging
 import pickle
-from six.moves import cStringIO as StringIO
+from io import BytesIO
 
 try:
     long_type = long  # noqa
@@ -40,7 +40,7 @@ def python_memcache_serializer(key, value):
         value = "%d" % value
     else:
         flags |= FLAG_PICKLE
-        output = StringIO()
+        output = BytesIO()
         pickler = pickle.Pickler(output, 0)
         pickler.dump(value)
         value = output.getvalue()
@@ -60,7 +60,7 @@ def python_memcache_deserializer(key, value, flags):
 
     if flags & FLAG_PICKLE:
         try:
-            buf = StringIO(value)
+            buf = BytesIO(value)
             unpickler = pickle.Unpickler(buf)
             return unpickler.load()
         except Exception:

--- a/pymemcache/serde.py
+++ b/pymemcache/serde.py
@@ -20,6 +20,11 @@ try:
 except ImportError:
     from StringIO import StringIO
 
+try:
+    long_type = long  # noqa
+except NameError:
+    long_type = None
+
 
 FLAG_PICKLE = 1 << 0
 FLAG_INTEGER = 1 << 1
@@ -34,7 +39,7 @@ def python_memcache_serializer(key, value):
     elif isinstance(value, int):
         flags |= FLAG_INTEGER
         value = "%d" % value
-    elif isinstance(value, long):
+    elif long_type is not None and isinstance(value, long_type):
         flags |= FLAG_LONG
         value = "%d" % value
     else:
@@ -55,7 +60,7 @@ def python_memcache_deserializer(key, value, flags):
         return int(value)
 
     if flags & FLAG_LONG:
-        return long(value)
+        return long_type(value)
 
     if flags & FLAG_PICKLE:
         try:

--- a/pymemcache/test/test_serde.py
+++ b/pymemcache/test/test_serde.py
@@ -1,0 +1,24 @@
+from unittest import TestCase
+
+from pymemcache.serde import (python_memcache_serializer,
+                              python_memcache_deserializer)
+
+
+class TestSerde(TestCase):
+
+    def check(self, value):
+        serialized, flags = python_memcache_serializer(b'key', value)
+        deserialized = python_memcache_deserializer(b'key', serialized, flags)
+        assert deserialized == value
+
+    def test_str(self):
+        self.check('value')
+
+    def test_int(self):
+        self.check(1)
+
+    def test_long(self):
+        self.check(123123123123123123123)
+
+    def test_pickleable(self):
+        self.check({'a': 'dict'})

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, pypy, pypy3, py33, py34, docs, flake8
+envlist = py26, py27, pypy, pypy3, py33, py34, docs, py27-flake8, py34-flake8
 
 [testenv]
 commands =
@@ -7,7 +7,12 @@ commands =
     pip install -e .
     py.test {posargs:pymemcache/test/}
 
-[testenv:flake8]
+[testenv:py27-flake8]
+commands =
+    pip install flake8
+    flake8 pymemcache/
+
+[testenv:py34-flake8]
 commands =
     pip install flake8
     flake8 pymemcache/


### PR DESCRIPTION
* Add linting on Python 3 too - normal environment failed for me initially since my `tox` is installed with Python 3 and so `flake8` failed on the syntax errors in `serde`
* Fix `serde` to be importable in Python 3
* Add some tests for `serde`