### PR TITLE
Prevent pytest-warning on pytest 3.0+

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,9 +6,9 @@ tag = True
 [bdist_wheel]
 universal = true
 
-[pytest]
+[tool:pytest]
 norecursedirs = build docs/_build *.egg .tox *.venv
-addopts = 
+addopts =
 	--verbose
 	--tb=short
 	--capture=no
@@ -17,7 +17,7 @@ addopts =
 	-rfEsxX
 	--cov=pymemcache --cov-report=xml --cov-report=term-missing
 	-m unit
-markers = 
+markers =
 	unit
 	integration
 	benchmark


### PR DESCRIPTION
Prevent `WC1 None [pytest] section in setup.cfg files is deprecated, use [tool:pytest] instead.`, as per pytest-dev/pytest#567.