### PR TITLE
Use cPickle if available on Python 2

### DIFF
--- a/pymemcache/serde.py
+++ b/pymemcache/serde.py
@@ -14,15 +14,7 @@
 
 import logging
 from io import BytesIO
-import six
-
-if six.PY2:
-    try:
-        import cPickle as pickle
-    except ImportError:
-        import pickle
-else:
-    import pickle
+from six.moves import cPickle as pickle
 
 try:
     long_type = long  # noqa

--- a/pymemcache/serde.py
+++ b/pymemcache/serde.py
@@ -12,8 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+
 import logging
-import pickle
 from io import BytesIO
 
 try:

--- a/pymemcache/serde.py
+++ b/pymemcache/serde.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
-
 import logging
 from io import BytesIO
+import six
+
+if six.PY2:
+    try:
+        import cPickle as pickle
+    except ImportError:
+        import pickle
+else:
+    import pickle
 
 try:
     long_type = long  # noqa


### PR DESCRIPTION
Using cPickle can result in big speed boosts according to the [Python docs on `pickle`](https://docs.python.org/2/library/pickle.html#relationship-to-other-python-modules)

> The pickle module has an optimized cousin called the cPickle module. As its name implies, cPickle is written in C, so it can be up to 1000 times faster than pickle

For Python 2, you need to import `cPickle` explicitly. In Python 3, `import pickle` chooses `cPickle` automatically if it's available. 