### PR TITLE
Add optional support for unicode keys

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,3 +123,4 @@ Credits
 * `Ernest W. Durbin III <https://github.com/ewdurbin>`_
 * `Remco van Oosterhout <https://github.com/Vhab>`_
 * `Nicholas Charriere <https://github.com/nichochar>`_
+* `Joe Gordon <https://github.com/jogo>`_

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -63,8 +63,11 @@ This client implements the ASCII protocol of memcached. This means keys should n
 contain any of the following illegal characters:
 > Keys cannot have spaces, new lines, carriage returns, or null characters.
 We suggest that if you have unicode characters, or long keys, you use an effective
-hashing mechanism before calling this client. At Pinterest, we have found that murmur3 hash is a
-great candidate for this.
+hashing mechanism before calling this client. At Pinterest, we have found that
+murmur3 hash is a great candidate for this. Alternatively you can
+set `allow_unicode_keys` to support unicode keys, but beware of
+what unicode encoding you use to make sure multiple clients can find the
+same key.
 
 
 Best Practices

--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -30,6 +30,7 @@ class HashClient(object):
         dead_timeout=60,
         use_pooling=False,
         ignore_exc=False,
+        allow_unicode_keys=False
     ):
         """
         Constructor.
@@ -66,6 +67,7 @@ class HashClient(object):
         self.use_pooling = use_pooling
         self.key_prefix = key_prefix
         self.ignore_exc = ignore_exc
+        self.allow_unicode_keys = allow_unicode_keys
         self._failed_clients = {}
         self._dead_clients = {}
         self._last_dead_check_time = time.time()
@@ -80,6 +82,7 @@ class HashClient(object):
             'key_prefix': key_prefix,
             'serializer': serializer,
             'deserializer': deserializer,
+            'allow_unicode_keys': allow_unicode_keys,
         }
 
         if use_pooling is True:
@@ -113,7 +116,7 @@ class HashClient(object):
         self.hasher.remove_node(key)
 
     def _get_client(self, key):
-        _check_key(key, self.key_prefix)
+        _check_key(key, self.allow_unicode_keys, self.key_prefix)
         if len(self._dead_clients) > 0:
             current_time = time.time()
             ldc = self._last_dead_check_time

--- a/pymemcache/client/rendezvous.py
+++ b/pymemcache/client/rendezvous.py
@@ -36,7 +36,7 @@ class RendezvousHash(object):
 
         for node in self.nodes:
             score = self.hash_function(
-                "%s-%s" % (str(node), str(key)))
+                "%s-%s" % (node, key))
 
             if score > high_score:
                 (high_score, winner) = (score, node)

--- a/pymemcache/test/test_client_hash.py
+++ b/pymemcache/test/test_client_hash.py
@@ -12,8 +12,8 @@ import socket
 
 class TestHashClient(ClientTestMixin, unittest.TestCase):
 
-    def make_client_pool(self, hostname, mock_socket_values, serializer=None):
-        mock_client = Client(hostname, serializer=serializer)
+    def make_client_pool(self, hostname, mock_socket_values, serializer=None, **kwargs):
+        mock_client = Client(hostname, serializer=serializer, **kwargs)
         mock_client.sock = MockSocket(mock_socket_values)
         client = PooledClient(hostname, serializer=serializer)
         client.client_pool = pool.ObjectPool(lambda: mock_client)
@@ -28,7 +28,8 @@ class TestHashClient(ClientTestMixin, unittest.TestCase):
             s = '%s:%s' % (ip, current_port)
             c = self.make_client_pool(
                 (ip, current_port),
-                vals
+                vals,
+                **kwargs
             )
             client.clients[s] = c
             client.hasher.add_node(s)

--- a/pymemcache/test/utils.py
+++ b/pymemcache/test/utils.py
@@ -26,12 +26,14 @@ class MockMemcacheClient(object):
                  timeout=None,
                  no_delay=False,
                  ignore_exc=False,
-                 default_noreply=True):
+                 default_noreply=True,
+                 allow_unicode_keys=False):
 
         self._contents = {}
 
         self.serializer = serializer
         self.deserializer = deserializer
+        self.allow_unicode_keys = allow_unicode_keys
 
         # Unused, but present for interface compatibility
         self.server = server
@@ -41,13 +43,14 @@ class MockMemcacheClient(object):
         self.ignore_exc = ignore_exc
 
     def get(self, key, default=None):
-        if isinstance(key, six.text_type):
-            raise MemcacheIllegalInputError(key)
-        if isinstance(key, six.string_types):
-            try:
-                key = key.encode('ascii')
-            except (UnicodeEncodeError, UnicodeDecodeError):
-                raise MemcacheIllegalInputError
+        if not self.allow_unicode_keys:
+            if isinstance(key, six.text_type):
+                raise MemcacheIllegalInputError(key)
+            if isinstance(key, six.string_types):
+                try:
+                    key = key.encode('ascii')
+                except (UnicodeEncodeError, UnicodeDecodeError):
+                    raise MemcacheIllegalInputError
 
         if key not in self._contents:
             return default
@@ -72,15 +75,16 @@ class MockMemcacheClient(object):
     get_multi = get_many
 
     def set(self, key, value, expire=0, noreply=True):
-        if isinstance(key, six.text_type):
-            raise MemcacheIllegalInputError(key)
+        if not self.allow_unicode_keys:
+            if isinstance(key, six.text_type):
+                raise MemcacheIllegalInputError(key)
+            if isinstance(key, six.string_types):
+                try:
+                    key = key.encode('ascii')
+                except (UnicodeEncodeError, UnicodeDecodeError):
+                    raise MemcacheIllegalInputError
         if isinstance(value, six.text_type):
             raise MemcacheIllegalInputError(value)
-        if isinstance(key, six.string_types):
-            try:
-                key = key.encode('ascii')
-            except (UnicodeEncodeError, UnicodeDecodeError):
-                raise MemcacheIllegalInputError
         if isinstance(value, six.string_types):
             try:
                 value = value.encode('ascii')

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 mock
 pytest
 pytest-cov
+gevent; "PyPy" not in platform_python_implementation

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, pypy, pypy3, py33, py34, py35, docs, py27-flake8, py35-flake8
+envlist = py26, py27, pypy, pypy3, py33, py34, py35, docs, py27-flake8, py35-flake8, integration
 skip_missing_interpreters = True
 
 [testenv]
@@ -7,6 +7,12 @@ commands =
     pip install -r test-requirements.txt
     pip install -e .
     py.test {posargs:pymemcache/test/}
+
+[testenv:integration]
+commands =
+    pip install -r test-requirements.txt
+    pip install -e .
+    py.test {posargs:pymemcache/test/ -m integration}
 
 [testenv:py27-flake8]
 commands =


### PR DESCRIPTION
memcached's ASCII protocol supports unicode keys, so lets support them
as well. Since using unicode keys for memcache is uncommon and to
preserve the previous behavior disable support by default.