### PR TITLE
Python 3 serialization fixes, serialization improvements

### DIFF
--- a/pymemcache/serde.py
+++ b/pymemcache/serde.py
@@ -23,6 +23,7 @@ except NameError:
     long_type = None
 
 
+FLAG_BYTES = 0
 FLAG_PICKLE = 1 << 0
 FLAG_INTEGER = 1 << 1
 FLAG_LONG = 1 << 2

--- a/pymemcache/serde.py
+++ b/pymemcache/serde.py
@@ -36,18 +36,18 @@ def python_memcache_serializer(key, value):
 
     # Check against exact types so that subclasses of native types will be
     # restored as their native type
-    if value_type == six.binary_type:
+    if value_type is six.binary_type:
         pass
 
-    elif value_type == six.text_type:
+    elif value_type is six.text_type:
         flags |= FLAG_TEXT
         value = value.encode('utf8')
 
-    elif value_type == int:
+    elif value_type is int:
         flags |= FLAG_INTEGER
         value = "%d" % value
 
-    elif six.PY2 and value_type == long_type:
+    elif six.PY2 and value_type is long_type:
         flags |= FLAG_LONG
         value = "%d" % value
 

--- a/pymemcache/serde.py
+++ b/pymemcache/serde.py
@@ -14,6 +14,7 @@
 
 import logging
 from io import BytesIO
+import six
 from six.moves import cPickle as pickle
 
 try:
@@ -25,19 +26,31 @@ except NameError:
 FLAG_PICKLE = 1 << 0
 FLAG_INTEGER = 1 << 1
 FLAG_LONG = 1 << 2
+FLAG_COMPRESSED = 1 << 3  # unused, to main compatability with python-memcached
+FLAG_TEXT = 1 << 4
 
 
 def python_memcache_serializer(key, value):
     flags = 0
+    value_type = type(value)
 
-    if isinstance(value, str):
+    # Check against exact types so that subclasses of native types will be
+    # restored as their native type
+    if value_type == six.binary_type:
         pass
-    elif isinstance(value, int):
+
+    elif value_type == six.text_type:
+        flags |= FLAG_TEXT
+        value = value.encode('utf8')
+
+    elif value_type == int:
         flags |= FLAG_INTEGER
         value = "%d" % value
-    elif long_type is not None and isinstance(value, long_type):
+
+    elif six.PY2 and value_type == long_type:
         flags |= FLAG_LONG
         value = "%d" % value
+
     else:
         flags |= FLAG_PICKLE
         output = BytesIO()
@@ -52,13 +65,19 @@ def python_memcache_deserializer(key, value, flags):
     if flags == 0:
         return value
 
-    if flags & FLAG_INTEGER:
+    elif flags & FLAG_TEXT:
+        return value.decode('utf8')
+
+    elif flags & FLAG_INTEGER:
         return int(value)
 
-    if flags & FLAG_LONG:
-        return long_type(value)
+    elif flags & FLAG_LONG:
+        if six.PY3:
+            return int(value)
+        else:
+            return long_type(value)
 
-    if flags & FLAG_PICKLE:
+    elif flags & FLAG_PICKLE:
         try:
             buf = BytesIO(value)
             unpickler = pickle.Unpickler(buf)

--- a/pymemcache/serde.py
+++ b/pymemcache/serde.py
@@ -36,7 +36,7 @@ def python_memcache_serializer(key, value):
 
     # Check against exact types so that subclasses of native types will be
     # restored as their native type
-    if value_type is six.binary_type:
+    if value_type is bytes:
         pass
 
     elif value_type is six.text_type:

--- a/pymemcache/test/test_integration.py
+++ b/pymemcache/test/test_integration.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import defaultdict
 import json
 import pytest
 import six
@@ -249,9 +250,16 @@ def test_serde_serialization(client_class, host, port, socket_module):
 
     check(b'byte string')
     check(u'unicode string')
+    check('olé')
+    check(u'olé')
     check(1)
     check(123123123123123123123)
     check({'a': 'pickle'})
+    check([u'one pickle', u'two pickle'])
+    testdict = defaultdict(int)
+    testdict[u'one pickle']
+    testdict[b'two pickle']
+    check(testdict)
 
 
 @pytest.mark.integration()

--- a/pymemcache/test/test_integration.py
+++ b/pymemcache/test/test_integration.py
@@ -242,6 +242,7 @@ def test_serde_serialization(client_class, host, port, socket_module):
         client.set(b'key', value, noreply=False)
         result = client.get(b'key')
         assert result == value
+        assert type(result) is type(value)
 
     client = client_class((host, port), serializer=python_memcache_serializer,
                           deserializer=python_memcache_deserializer,

--- a/pymemcache/test/test_serde.py
+++ b/pymemcache/test/test_serde.py
@@ -2,8 +2,8 @@
 from unittest import TestCase
 
 from pymemcache.serde import (python_memcache_serializer,
-                              python_memcache_deserializer, FLAG_PICKLE,
-                              FLAG_INTEGER, FLAG_LONG, FLAG_TEXT)
+                              python_memcache_deserializer, FLAG_BYTES,
+                              FLAG_PICKLE, FLAG_INTEGER, FLAG_LONG, FLAG_TEXT)
 import pytest
 import six
 
@@ -21,7 +21,7 @@ class CustomInt(int):
 @pytest.mark.unit()
 class TestSerde(TestCase):
 
-    def check(self, value, expected_flags=0):
+    def check(self, value, expected_flags):
         serialized, flags = python_memcache_serializer(b'key', value)
         assert flags == expected_flags
 
@@ -34,8 +34,8 @@ class TestSerde(TestCase):
         assert deserialized == value
 
     def test_bytes(self):
-        self.check(b'value')
-        self.check(b'\xc2\xa3 $ \xe2\x82\xac')  # £ $ €
+        self.check(b'value', FLAG_BYTES)
+        self.check(b'\xc2\xa3 $ \xe2\x82\xac', FLAG_BYTES)  # £ $ €
 
     def test_unicode(self):
         self.check(u'value', FLAG_TEXT)

--- a/pymemcache/test/test_serde.py
+++ b/pymemcache/test/test_serde.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from unittest import TestCase
 
 from pymemcache.serde import (python_memcache_serializer,
@@ -34,9 +35,11 @@ class TestSerde(TestCase):
 
     def test_bytes(self):
         self.check(b'value')
+        self.check(b'\xc2\xa3 $ \xe2\x82\xac')  # £ $ €
 
     def test_unicode(self):
         self.check(u'value', FLAG_TEXT)
+        self.check(u'£ $ €', FLAG_TEXT)
 
     def test_int(self):
         self.check(1, FLAG_INTEGER)

--- a/pymemcache/test/test_serde.py
+++ b/pymemcache/test/test_serde.py
@@ -7,6 +7,16 @@ import pytest
 import six
 
 
+class CustomInt(int):
+    """
+    Custom integer type for testing.
+
+    Entirely useless, but used to show that built in types get serialized and
+    deserialized back as the same type of object.
+    """
+    pass
+
+
 @pytest.mark.unit()
 class TestSerde(TestCase):
 
@@ -42,3 +52,7 @@ class TestSerde(TestCase):
 
     def test_pickleable(self):
         self.check({'a': 'dict'}, FLAG_PICKLE)
+
+    def test_subtype(self):
+        # Subclass of a native type will be restored as the same type
+        self.check(CustomInt(123123), FLAG_PICKLE)

--- a/pymemcache/test/test_serde.py
+++ b/pymemcache/test/test_serde.py
@@ -2,17 +2,29 @@ from unittest import TestCase
 
 from pymemcache.serde import (python_memcache_serializer,
                               python_memcache_deserializer)
+import pytest
+import six
 
 
+@pytest.mark.unit()
 class TestSerde(TestCase):
 
     def check(self, value):
         serialized, flags = python_memcache_serializer(b'key', value)
+
+        # pymemcache stores values as byte strings, so we immediately the value
+        # if needed so deserialized works as it would with a real server
+        if not isinstance(serialized, six.binary_type):
+            serialized = six.text_type(serialized).encode('ascii')
+
         deserialized = python_memcache_deserializer(b'key', serialized, flags)
         assert deserialized == value
 
-    def test_str(self):
-        self.check('value')
+    def test_bytes(self):
+        self.check(b'value')
+
+    def test_unicode(self):
+        self.check(u'value')
 
     def test_int(self):
         self.check(1)


### PR DESCRIPTION
I was looking at trying to use/resurrect django-pymemcache, however in trying to update it and get tests working on it - pymemcache serialization seems to have some issues with byte/unicode strings. This is mostly a Python 3 problem, but could cause problems elsewhere.

To solve this problem, I've taken a similar approach to https://github.com/linsomniac/python-memcached/pull/100/files:

- Only byte strings get serialized without a flag
- Unicode strings get serialized with a different text flag
- Only specific builtin types get flags added, everything else gets pickled

Also `test_serde.py` wasn't being picked up with pytest as it didn't have a decorator - so I've added that.