### PR TITLE
remove suggestion to use python-clandestined

### DIFF
--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -54,11 +54,6 @@ class HashClient(object):
 
         Further arguments are interpreted as for :py:class:`.Client`
         constructor.
-
-        The default ``hasher`` is using a pure python implementation that can
-        be significantly improved performance wise by switching to a C based
-        version. We recommend using ``python-clandestined`` if having a C
-        dependency is acceptable.
         """
         self.clients = {}
         self.retry_attempts = retry_attempts


### PR DESCRIPTION
this note is misleading, as the hasher is expected to expose a `get_node`
method. clandestined's `RendezvousHash` does not implement this method.

when clandestined's implementation was copied into pymemcached in commit
cff5abfad59baa593996fe7e240fd3944e2c4af2, the method was renamed from
`find_node` to `get_node`, breaking compatibility.