### PR TITLE
Raising MemcacheIllegalInputError when key contains null byte, newline, or carriage return

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -92,20 +92,27 @@ def _check_key(key, allow_unicode_keys, key_prefix=b''):
         except (UnicodeEncodeError, UnicodeDecodeError):
             raise MemcacheIllegalInputError("Non-ASCII key: '%r'" % (key,))
     key = key_prefix + key
-    if b' ' in key or b'\n' in key:
-        raise MemcacheIllegalInputError(
-          "Key contains space and/or newline: '%r'" % (key,)
-        )
-    if b'\00' in key:
-        raise MemcacheIllegalInputError(
-          "Key contains null byte: '%r'" % (key,)
-        )
-    if b'\r\n' in key:
-        raise MemcacheIllegalInputError(
-          "Key contains carriage return: '%r'" % (key,)
-        )
+
     if len(key) > 250:
         raise MemcacheIllegalInputError("Key is too long: '%r'" % (key,))
+
+    for c in key:
+        if c == b' ':
+            raise MemcacheIllegalInputError(
+                "Key contains space: '%r'" % (key,)
+            )
+        elif c == b'\n':
+            raise MemcacheIllegalInputError(
+                "Key contains newline: '%r'" % (key,)
+            )
+        elif c == b'\00':
+            raise MemcacheIllegalInputError(
+              "Key contains null byte: '%r'" % (key,)
+            )
+        elif c == b'\r':
+            raise MemcacheIllegalInputError(
+              "Key contains carriage return: '%r'" % (key,)
+            )
     return key
 
 

--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -92,7 +92,7 @@ def _check_key(key, allow_unicode_keys, key_prefix=b''):
         except (UnicodeEncodeError, UnicodeDecodeError):
             raise MemcacheIllegalInputError("Non-ASCII key: '%r'" % (key,))
     key = key_prefix + key
-    
+
     if len(key) > 250:
         raise MemcacheIllegalInputError("Key is too long: '%r'" % (key,))
 
@@ -107,7 +107,7 @@ def _check_key(key, allow_unicode_keys, key_prefix=b''):
             )
         elif c == b'\00':
             raise MemcacheIllegalInputError(
-              "Key contains null byte: '%r'" % (key,)
+              "Key contains null character: '%r'" % (key,)
             )
         elif c == b'\r':
             raise MemcacheIllegalInputError(

--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -97,19 +97,21 @@ def _check_key(key, allow_unicode_keys, key_prefix=b''):
         raise MemcacheIllegalInputError("Key is too long: '%r'" % (key,))
 
     for c in key:
-        if c == b' ':
+        if isinstance(c, VALID_STRING_TYPES):
+            c = ord(c)
+        if c == ord(b' '):
             raise MemcacheIllegalInputError(
                 "Key contains space: '%r'" % (key,)
             )
-        elif c == b'\n':
+        elif c == ord(b'\n'):
             raise MemcacheIllegalInputError(
                 "Key contains newline: '%r'" % (key,)
             )
-        elif c == b'\00':
+        elif c == ord(b'\00'):
             raise MemcacheIllegalInputError(
               "Key contains null character: '%r'" % (key,)
             )
-        elif c == b'\r':
+        elif c == ord(b'\r'):
             raise MemcacheIllegalInputError(
               "Key contains carriage return: '%r'" % (key,)
             )

--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -96,9 +96,7 @@ def _check_key(key, allow_unicode_keys, key_prefix=b''):
     if len(key) > 250:
         raise MemcacheIllegalInputError("Key is too long: '%r'" % (key,))
 
-    for c in key:
-        if isinstance(c, VALID_STRING_TYPES):
-            c = ord(c)
+    for c in bytearray(key):
         if c == ord(b' '):
             raise MemcacheIllegalInputError(
                 "Key contains space: '%r'" % (key,)

--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -96,6 +96,14 @@ def _check_key(key, allow_unicode_keys, key_prefix=b''):
         raise MemcacheIllegalInputError(
           "Key contains space and/or newline: '%r'" % (key,)
         )
+    if b'\00' in key:
+        raise MemcacheIllegalInputError(
+          "Key contains null byte: '%r'" % (key,)
+        )
+    if b'\r\n' in key:
+        raise MemcacheIllegalInputError(
+          "Key contains carriage return: '%r'" % (key,)
+        )
     if len(key) > 250:
         raise MemcacheIllegalInputError("Key is too long: '%r'" % (key,))
     return key

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -132,33 +132,6 @@ class ClientTestMixin(object):
         with pytest.raises(MemcacheIllegalInputError):
             _set()
 
-    def test_set_key_with_space(self):
-        client = self.make_client([b''])
-
-        def _set():
-            client.set(b'key has space', b'value', noreply=False)
-
-        with pytest.raises(MemcacheIllegalInputError):
-            _set()
-
-    def test_set_key_with_newline(self):
-        client = self.make_client([b''])
-
-        def _set():
-            client.set(b'key\n', b'value', noreply=False)
-
-        with pytest.raises(MemcacheIllegalInputError):
-            _set()
-
-    def test_set_key_with_carriage_return(self):
-        client = self.make_client([b''])
-
-        def _set():
-            client.set(b'key\r\n', b'value', noreply=False)
-
-        with pytest.raises(MemcacheIllegalInputError):
-            _set()
-
     def test_set_unicode_char_in_middle_of_key_ok(self):
         client = self.make_client([b'STORED\r\n'], allow_unicode_keys=True)
 
@@ -579,6 +552,33 @@ class TestClient(ClientTestMixin, unittest.TestCase):
             client.set(b'key', b'value', noreply=False)
 
         with pytest.raises(MemcacheUnknownError):
+            _set()
+
+    def test_set_key_with_space(self):
+        client = self.make_client([b''])
+
+        def _set():
+            client.set(b'key has space', b'value', noreply=False)
+
+        with pytest.raises(MemcacheIllegalInputError):
+            _set()
+
+    def test_set_key_with_newline(self):
+        client = self.make_client([b''])
+
+        def _set():
+            client.set(b'key\n', b'value', noreply=False)
+
+        with pytest.raises(MemcacheIllegalInputError):
+            _set()
+
+    def test_set_key_with_carriage_return(self):
+        client = self.make_client([b''])
+
+        def _set():
+            client.set(b'key\r\n', b'value', noreply=False)
+
+        with pytest.raises(MemcacheIllegalInputError):
             _set()
 
     def test_set_many_socket_handling(self):

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -132,6 +132,33 @@ class ClientTestMixin(object):
         with pytest.raises(MemcacheIllegalInputError):
             _set()
 
+    def test_set_key_with_space(self):
+        client = self.make_client([b''])
+
+        def _set():
+            client.set(b'key has space', b'value', noreply=False)
+
+        with pytest.raises(MemcacheIllegalInputError):
+            _set()
+
+    def test_set_key_with_newline(self):
+        client = self.make_client([b''])
+
+        def _set():
+            client.set(b'key\n', b'value', noreply=False)
+
+        with pytest.raises(MemcacheIllegalInputError):
+            _set()
+
+    def test_set_key_with_carriage_return(self):
+        client = self.make_client([b''])
+
+        def _set():
+            client.set(b'key\r\n', b'value', noreply=False)
+
+        with pytest.raises(MemcacheIllegalInputError):
+            _set()
+
     def test_set_unicode_char_in_middle_of_key_ok(self):
         client = self.make_client([b'STORED\r\n'], allow_unicode_keys=True)
 
@@ -664,7 +691,7 @@ class TestClient(ClientTestMixin, unittest.TestCase):
         with pytest.raises(MemcacheClientError):
             client.get(u'\u0FFF'*150)
 
-    def test_key_contains_spae(self):
+    def test_key_contains_space(self):
         client = self.make_client([b'END\r\n'])
         with pytest.raises(MemcacheClientError):
             client.get(b'abc xyz')

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -581,6 +581,15 @@ class TestClient(ClientTestMixin, unittest.TestCase):
         with pytest.raises(MemcacheIllegalInputError):
             _set()
 
+    def test_set_key_with_null_character(self):
+        client = self.make_client([b''])
+
+        def _set():
+            client.set(b'key\00', b'value', noreply=False)
+
+        with pytest.raises(MemcacheIllegalInputError):
+            _set()
+
     def test_set_many_socket_handling(self):
         client = self.make_client([b'STORED\r\n'])
         result = client.set_many({b'key': b'value'}, noreply=False)

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -576,7 +576,7 @@ class TestClient(ClientTestMixin, unittest.TestCase):
         client = self.make_client([b''])
 
         def _set():
-            client.set(b'key\r\n', b'value', noreply=False)
+            client.set(b'key\r', b'value', noreply=False)
 
         with pytest.raises(MemcacheIllegalInputError):
             _set()


### PR DESCRIPTION
Memcache does not support setting keys with null byte, newline, carriage return. This adds support for checking the key to ensure the key is valid.

Setting keys with these returns the following exception:

```python
>>> client.set('\r\ntest', 'foo')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "lib/memcache.py", line 139, in set
    return super(Client, self).set(key, value, expire=expire, noreply=noreply)
  File .../env/lib/python2.7/site-packages/pymemcache/client/base.py", line 256, in set
    return self._store_cmd(b'set', key, expire, noreply, value)
  File .../env/lib/python2.7/site-packages/pymemcache/client/base.py", line 747, in _store_cmd
    self._raise_errors(line, name)
  File ".../env/lib/python2.7/site-packages/pymemcache/client/base.py", line 654, in _raise_errors
    raise MemcacheUnknownCommandError(name)
pymemcache.exceptions.MemcacheUnknownCommandError: set
```

This has been tested using version 1.3.5 on python 2.7.10