### PR TITLE
Kill python 2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
     url='https://github.com/Pinterest/pymemcache',
     classifiers=[
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, pypy, py33, py34, py35, docs, py27-flake8, py35-flake8, integration
+envlist = py27, pypy, py33, py34, py35, docs, py27-flake8, py35-flake8, integration
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
As decided in https://github.com/pinterest/pymemcache/issues/139, killing support for python 2.6