### PR TITLE
Remove docs from being run when you're running tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, pypy, py33, py34, py35, docs, py27-flake8, py35-flake8, integration
+envlist = py27, pypy, py33, py34, py35, py27-flake8, py35-flake8, integration
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Whenever you run tox locally, it builds the docs. This has the effect of building a bunch of new files that need cleaning.

Readthedocs builds the docs by itself, it doesn't need them to be checked in anyway, so this makes sure tox.ini is idempotent and doesn't modify any local files.