### PR TITLE
Exclude well-known non-code paths from flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ markers =
 [flake8]
 show-source = True
 max-line-length = 80
+exclude = .tox/*,.venv/*,docs/*
 
 [bumpversion:file:pymemcache/__init__.py]
 

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,9 @@ from pymemcache import __version__
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
+
 readme = read('README.rst')
 changelog = read('ChangeLog.rst')
-
 
 setup(
     name='pymemcache',


### PR DESCRIPTION
Also fix a minor flake8 issue in `setup.py`.