### PR TITLE
Use only the highest, premium quality pickler available at runtime.

### DIFF
--- a/pymemcache/serde.py
+++ b/pymemcache/serde.py
@@ -30,6 +30,14 @@ FLAG_LONG = 1 << 2
 FLAG_COMPRESSED = 1 << 3  # unused, to main compatability with python-memcached
 FLAG_TEXT = 1 << 4
 
+# Pickle protocol version (-1 for highest available to runtime)
+# Warning with `0`: If somewhere in your value lies a slotted object,
+# ie defines `__slots__`, even if you do not include it in your pickleable
+# state via `__getstate__`, python will complain with something like:
+#   TypeError: a class that defines __slots__ without defining __getstate__
+#   cannot be pickled
+PICKLE_VERSION = -1
+
 
 def python_memcache_serializer(key, value):
     flags = 0
@@ -55,7 +63,7 @@ def python_memcache_serializer(key, value):
     else:
         flags |= FLAG_PICKLE
         output = BytesIO()
-        pickler = pickle.Pickler(output, 0)
+        pickler = pickle.Pickler(output, PICKLE_VERSION)
         pickler.dump(value)
         value = output.getvalue()
 


### PR DESCRIPTION
Also include a forewarning note on Python "pickleableness".

This also allows easier changing as it's now a constant. While not perfect, it's certainly helpful for me at least!

The issue with version 0 is that some objects which *should* be pickleable are not.

Namely this scenario:

* An object defines `__getstate__` to select the state to be pickled and restored.
* This object contains a non-pickleable slotted object in an attribute value (ie defines `__slots__`)
* Said attribute happens to be specifically excluded from the state dictionary returned from `__getstate__` of it's parent, but alias, cPython with pickle version zero returns:

`*** TypeError: a class that defines __slots__ without defining __getstate__ cannot be pickled`

Fun stuff. Thanks for the lib.