### PR TITLE
Don't Raise Generic Exception

### DIFF
--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -4,6 +4,7 @@ import logging
 
 from pymemcache.client.base import Client, PooledClient, _check_key
 from pymemcache.client.rendezvous import RendezvousHash
+from pymemcache.exceptions import MemcacheError
 
 logger = logging.getLogger(__name__)
 
@@ -132,7 +133,7 @@ class HashClient(object):
         if server is None:
             if self.ignore_exc is True:
                 return
-            raise Exception('All servers seem to be down right now')
+            raise MemcacheError('All servers seem to be down right now')
 
         client = self.clients[server]
         return client

--- a/pymemcache/test/test_client_hash.py
+++ b/pymemcache/test/test_client_hash.py
@@ -1,6 +1,6 @@
 from pymemcache.client.hash import HashClient
 from pymemcache.client.base import Client, PooledClient
-from pymemcache.exceptions import MemcacheUnknownError
+from pymemcache.exceptions import MemcacheError, MemcacheUnknownError
 from pymemcache import pool
 
 from .test_client import ClientTestMixin, MockSocket
@@ -162,7 +162,7 @@ class TestHashClient(ClientTestMixin, unittest.TestCase):
             timeout=1, connect_timeout=1
         )
 
-        with pytest.raises(Exception) as e:
+        with pytest.raises(MemcacheError) as e:
             client._get_client('foo')
 
         assert str(e.value) == 'All servers seem to be down right now'


### PR DESCRIPTION
Libraries should raise library specific exceptions. Such as
MemcacheError. This enables users to easily catch exceptions generated
by library separate from other exceptions. Raising "Exception" forces
catching Exception and potentially masks all sorts of issues.