### PR TITLE
Close client socket if it fails to connect

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -253,12 +253,16 @@ class Client(object):
     def _connect(self):
         sock = self.socket_module.socket(self.socket_module.AF_INET,
                                          self.socket_module.SOCK_STREAM)
-        sock.settimeout(self.connect_timeout)
-        sock.connect(self.server)
-        sock.settimeout(self.timeout)
-        if self.no_delay:
-            sock.setsockopt(self.socket_module.IPPROTO_TCP,
-                            self.socket_module.TCP_NODELAY, 1)
+        try:
+            sock.settimeout(self.connect_timeout)
+            sock.connect(self.server)
+            sock.settimeout(self.timeout)
+            if self.no_delay:
+                sock.setsockopt(self.socket_module.IPPROTO_TCP,
+                                self.socket_module.TCP_NODELAY, 1)
+        except Exception:
+            sock.close()
+            raise
         self.sock = sock
 
     def close(self):


### PR DESCRIPTION
If Client._connect fails, it should close the socket before re-raising
the exception; the caller can't do this because the socket is only
stored in a local variable until it's been fully connected.  Failing to
do this causes ResourceWarnings in Python 3.