### PR TITLE
Have MockMemcacheClient support non-ascii strings

### DIFF
--- a/pymemcache/test/test_utils.py
+++ b/pymemcache/test/test_utils.py
@@ -19,7 +19,7 @@ def test_get_set_non_ascii_value():
     assert client.get(b"hello") is None
 
     # This is the value of msgpack.packb('non_ascii')
-    non_ascii_str = '\xa9non_ascii'
+    non_ascii_str = b'\xa9non_ascii'
     client.set(b"hello", non_ascii_str)
     assert client.get(b"hello") == non_ascii_str
 
@@ -44,9 +44,9 @@ def test_get_many_set_many_non_ascii_values():
     client = MockMemcacheClient()
 
     # These are the values of calling msgpack.packb() on '1', '2', and '3'
-    non_ascii_1 = '\xa11'
-    non_ascii_2 = '\xa12'
-    non_ascii_3 = '\xa13'
+    non_ascii_1 = b'\xa11'
+    non_ascii_2 = b'\xa12'
+    non_ascii_3 = b'\xa13'
     client.set(b"h", non_ascii_1)
 
     result = client.get_many([b"h", b"e", b"l", b"o"])

--- a/pymemcache/test/test_utils.py
+++ b/pymemcache/test/test_utils.py
@@ -54,7 +54,9 @@ def test_get_many_set_many_non_ascii_values():
 
     # Convert keys into bytes
     d = dict((k.encode('ascii'), v)
-             for k, v in six.iteritems(dict(h=non_ascii_1, e=non_ascii_2, l=non_ascii_3)))
+             for k, v in six.iteritems(
+                dict(h=non_ascii_1, e=non_ascii_2, l=non_ascii_3)
+             ))
     client.set_many(d)
     assert client.get_many([b"h", b"e", b"l", b"o"]) == d
 

--- a/pymemcache/test/test_utils.py
+++ b/pymemcache/test/test_utils.py
@@ -14,6 +14,17 @@ def test_get_set():
 
 
 @pytest.mark.unit()
+def test_get_set_non_ascii_value():
+    client = MockMemcacheClient()
+    assert client.get(b"hello") is None
+
+    # This is the value of msgpack.packb('non_ascii')
+    non_ascii_str = '\xa9non_ascii'
+    client.set(b"hello", non_ascii_str)
+    assert client.get(b"hello") == non_ascii_str
+
+
+@pytest.mark.unit()
 def test_get_many_set_many():
     client = MockMemcacheClient()
     client.set(b"h", 1)
@@ -24,6 +35,26 @@ def test_get_many_set_many():
     # Convert keys into bytes
     d = dict((k.encode('ascii'), v)
              for k, v in six.iteritems(dict(h=1, e=2, l=3)))
+    client.set_many(d)
+    assert client.get_many([b"h", b"e", b"l", b"o"]) == d
+
+
+@pytest.mark.unit()
+def test_get_many_set_many_non_ascii_values():
+    client = MockMemcacheClient()
+
+    # These are the values of calling msgpack.packb() on '1', '2', and '3'
+    non_ascii_1 = '\xa11'
+    non_ascii_2 = '\xa12'
+    non_ascii_3 = '\xa13'
+    client.set(b"h", non_ascii_1)
+
+    result = client.get_many([b"h", b"e", b"l", b"o"])
+    assert result == {b"h": non_ascii_1}
+
+    # Convert keys into bytes
+    d = dict((k.encode('ascii'), v)
+             for k, v in six.iteritems(dict(h=non_ascii_1, e=non_ascii_2, l=non_ascii_3)))
     client.set_many(d)
     assert client.get_many([b"h", b"e", b"l", b"o"]) == d
 

--- a/pymemcache/test/utils.py
+++ b/pymemcache/test/utils.py
@@ -85,7 +85,7 @@ class MockMemcacheClient(object):
                     raise MemcacheIllegalInputError
         if isinstance(value, six.text_type):
             raise MemcacheIllegalInputError(value)
-        if isinstance(value, six.string_types):
+        if isinstance(value, six.string_types) and not isinstance(value, six.binary_type):
             try:
                 value = value.encode('ascii')
             except (UnicodeEncodeError, UnicodeDecodeError):

--- a/pymemcache/test/utils.py
+++ b/pymemcache/test/utils.py
@@ -85,7 +85,8 @@ class MockMemcacheClient(object):
                     raise MemcacheIllegalInputError
         if isinstance(value, six.text_type):
             raise MemcacheIllegalInputError(value)
-        if isinstance(value, six.string_types) and not isinstance(value, six.binary_type):
+        if (isinstance(value, six.string_types) and
+                not isinstance(value, six.binary_type)):
             try:
                 value = value.encode('ascii')
             except (UnicodeEncodeError, UnicodeDecodeError):


### PR DESCRIPTION
The current MockMemcacheClient doesn't support storage of non-ascii strings as values, but the real Client does. Here's an example:

The real Client on a local memcached:
```
>>> from pymemcache.client import Client
>>> client = Client(('localhost', 11211))
>>> binary_str = msgpack.packb('123')
>>> binary_str
'\xa3123'
>>> client.set('foo', binary_str)
True
>>> client.get('foo')
'\xa3123'
```

And the MockMemcacheClient:

```
>>> from pymemcache.test.utils import MockMemcacheClient
>>> mock = MockMemcacheClient()
>>> mock.set('foo', binary_str)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/edwardlim/Documents/dev/python_envs/chuggs/lib/python2.7/site-packages/pymemcache/test/utils.py", line 92, in set
    raise MemcacheIllegalInputError
pymemcache.exceptions.MemcacheIllegalInputError
```

This PR aims to close this gap between the mock and real clients.

Note: This was tested on pymemcache v1.4.3.