### PR TITLE
Update testing matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ matrix:
       env: TOXENV=py36,py36-flake8
     - python: pypy
       env: TOXENV=pypy
-# Drop pypy3 support until travis fixes python3 pypy interpreter path issue
-# https://github.com/travis-ci/travis-ci/issues/6304#ref-issue-177592739
+    - python: pypy3
+      env: TOXENV=pypy3
 
 services:
   - memcached

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,21 +3,27 @@ cache:
   directories:
     - $HOME/.cache/pip
 language: python
+matrix:
+  include:
+    - python: 2.6
+      env: TOXENV=py26
+    - python: 2.7
+      env: TOXENV=py27,py27-flake8
+    - python: 3.3
+      env: TOXENV=py33
+    - python: 3.4
+      env: TOXENV=py34
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36,py36-flake8
+    - python: pypy
+      env: TOXENV=pypy
+# Drop pypy3 support until travis fixes python3 pypy interpreter path issue
+# https://github.com/travis-ci/travis-ci/issues/6304#ref-issue-177592739
 
 services:
   - memcached
-
-env:
-  - TOXENV=py26
-  - TOXENV=py27
-  - TOXENV=py33
-  - TOXENV=py34
-  - TOXENV=py35
-  - TOXENV=py36
-  - TOXENV=pypy
-# - TOXENV=pypy3
-# Drop support until travis fixes python3 pypy interpreter path issue
-# https://github.com/travis-ci/travis-ci/issues/6304#ref-issue-177592739
 
 install:
   - travis_retry pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ env:
   - TOXENV=py27
   - TOXENV=py33
   - TOXENV=py34
+  - TOXENV=py35
+  - TOXENV=py36
   - TOXENV=pypy
 # - TOXENV=pypy3
 # Drop support until travis fixes python3 pypy interpreter path issue

--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -206,7 +206,7 @@ class HashClient(object):
                 raise
 
             return default_val
-        except:
+        except Exception:
             # any exceptions that aren't socket.error we need to handle
             # gracefully as well
             if not self.ignore_exc:

--- a/pymemcache/test/test_utils.py
+++ b/pymemcache/test/test_utils.py
@@ -34,9 +34,9 @@ def test_get_many_set_many():
 
     # Convert keys into bytes
     d = dict((k.encode('ascii'), v)
-             for k, v in six.iteritems(dict(h=1, e=2, l=3)))
+             for k, v in six.iteritems(dict(h=1, e=2, z=3)))
     client.set_many(d)
-    assert client.get_many([b"h", b"e", b"l", b"o"]) == d
+    assert client.get_many([b"h", b"e", b"z", b"o"]) == d
 
 
 @pytest.mark.unit()
@@ -55,10 +55,10 @@ def test_get_many_set_many_non_ascii_values():
     # Convert keys into bytes
     d = dict((k.encode('ascii'), v)
              for k, v in six.iteritems(
-                dict(h=non_ascii_1, e=non_ascii_2, l=non_ascii_3)
+                dict(h=non_ascii_1, e=non_ascii_2, z=non_ascii_3)
              ))
     client.set_many(d)
-    assert client.get_many([b"h", b"e", b"l", b"o"]) == d
+    assert client.get_many([b"h", b"e", b"z", b"o"]) == d
 
 
 @pytest.mark.unit()

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: PyPy',
         'License :: OSI Approved :: Apache Software License',
         'Topic :: Database',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,5 @@ mock
 pytest
 pytest-cov
 gevent==1.1; "PyPy" not in platform_python_implementation
+pylibmc
+python-memcached

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, pypy, py33, py34, py35, py27-flake8, py35-flake8, integration
+envlist = py27, py33, py34, py35, py36, pypy, pypy3, py27-flake8, py36-flake8, integration
 skip_missing_interpreters = True
 
 [testenv]
@@ -19,7 +19,7 @@ commands =
     pip install flake8
     flake8 pymemcache/
 
-[testenv:py35-flake8]
+[testenv:py36-flake8]
 commands =
     pip install flake8
     flake8 pymemcache/


### PR DESCRIPTION
* Test against python 3.5 and 3.6
* Run flake8 in travis
* Add missing python versions to travis config, previously some tests passed with:
    
        ERROR: InterpreterNotFound: python2.6
        SKIPPED:  py26: InterpreterNotFound: python2.6
