### PR TITLE
Enabling memory management from Client

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -660,6 +660,38 @@ class Client(object):
 
         return result
 
+    def slabs(self, *args):
+        """
+        The memcached "slabs" command.
+
+        The returned keys depend on what the "slabs" command returns.
+        A best effort is made to convert values to appropriate Python
+        types, defaulting to strings when a conversion cannot be made.
+
+        Args:
+          *arg: extra string arguments to the "stats" command. See the
+                memcached protocol documentation for more information.
+
+        Returns:
+          If no exception is raised, always returns True.
+          """
+        self._fetch_cmd(b'slabs', args, False)
+        return True
+
+    def cache_memlimit(self, memlimit):
+        """
+        The memcached "cache_memlimit" command.
+
+        Args:
+            A number of megabytes to set as the new memlimit
+
+        Returns:
+          If no exception is raised, always returns True.
+        """
+
+        self._fetch_cmd(b'cache_memlimit', [str(int(memlimit))], False)
+        return True
+
     def version(self):
         """
         The memcached "version" command.
@@ -742,7 +774,7 @@ class Client(object):
             while True:
                 buf, line = _readline(self.sock, buf)
                 self._raise_errors(line, name)
-                if line == b'END':
+                if line == b'END' or line == b'OK':
                     return result
                 elif line.startswith(b'VALUE'):
                     if expect_cas:


### PR DESCRIPTION
Additional parts of the memcached API needed to be implemented to allow manual memory management from the Client.  In most cases these changes are incredibly simple.  The only core change required was that command arguments in _fetch_cmd always be sent in the order in which they are passed by the caller (arguments were pulled from a dictionary in arbitrary order), which has been implemented.