### PR TITLE
Remove deprecated Python version. This makes tests fail at the moment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ matrix:
       env: TOXENV=py26
     - python: 2.7
       env: TOXENV=py27,py27-flake8
-    - python: 3.3
-      env: TOXENV=py33
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py36, pypy, pypy3, py27-flake8, py36-flake8, integration
+envlist = py27, py34, py35, py36, pypy, pypy3, py27-flake8, py36-flake8, integration
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
This is because `wheel` requires it *not* be `3.3.x`.

Of course, we can instead hack this to install some ancient wheel on an
ancient Python... but nobody should be running `3.3.x`, so it'd
just be cruft, at least in my garbage opinion ;)