### PR TITLE
fix django2.0

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,5 +1,9 @@
 Change Log
 ==========
+New in draft
+--------------------
+* Change set_many and set_multi api return value. see [pr](https://github.com/pinterest/pymemcache/pull/179)
+
 New in version 1.4.4
 --------------------
 * pypy3 to travis test matrix

--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -310,6 +310,7 @@ class Client(object):
 
         Returns:
           Returns a list of keys that failed to be inserted.
+          If noreply is True, alwais returns empty list.
         """
         # TODO: make this more performant by sending all the values first, then
         # waiting for all the responses.

--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -309,7 +309,7 @@ class Client(object):
                    self.default_noreply).
 
         Returns:
-            Empty list
+          Empty list
         """
 
         # TODO: make this more performant by sending all the values first, then

--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -309,17 +309,14 @@ class Client(object):
                    self.default_noreply).
 
         Returns:
-          If no exception is raised, always returns True. Otherwise all, some
-          or none of the keys have been successfully set. If noreply is True
-          then a successful return does not guarantee that any keys were
-          successfully set (just that the keys were successfully sent).
+            Empty list
         """
 
         # TODO: make this more performant by sending all the values first, then
         # waiting for all the responses.
         for key, value in six.iteritems(values):
             self.set(key, value, expire, noreply)
-        return True
+        return []
 
     set_multi = set_many
 
@@ -930,7 +927,8 @@ class PooledClient(object):
 
     def set_many(self, values, expire=0, noreply=None):
         with self.client_pool.get_and_release(destroy_on_fail=True) as client:
-            return client.set_many(values, expire=expire, noreply=noreply)
+            client.set_many(values, expire=expire, noreply=noreply)
+            return []
 
     set_multi = set_many
 

--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -318,7 +318,15 @@ class Client(object):
 
         failed = []
         for key, value in six.iteritems(values):
-            result = self._store_cmd(b'set', key, expire, noreply, value, None, (b'STORED', b'NOT_STORED'))
+            result = self._store_cmd(
+                b'set',
+                key,
+                expire,
+                noreply,
+                value,
+                None,
+                (b'STORED', b'NOT_STORED')
+            )
             if not result:
                 failed.append(key)
         return failed

--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -318,14 +318,7 @@ class Client(object):
 
         failed = []
         for key, value in six.iteritems(values):
-            result = self._store_cmd(
-                b'set',
-                key,
-                expire,
-                noreply,
-                value,
-                None,
-            )
+            result = self.set(key, value, expire, noreply)
             if not result:
                 failed.append(key)
         return failed

--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -309,7 +309,7 @@ class Client(object):
                    self.default_noreply).
 
         Returns:
-          Empty list
+          Returns a list of keys that failed to be inserted.
         """
         # TODO: make this more performant by sending all the values first, then
         # waiting for all the responses.

--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -338,7 +338,7 @@ class HashClient(object):
         for server, values in client_batches.items():
             client = self.clients['%s:%s' % server]
 
-            failed = self._safely_run_set_many(
+            failed += self._safely_run_set_many(
                 client, values, *args, **kwargs
             )
 

--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -241,13 +241,13 @@ class HashClient(object):
 
     def set_many(self, values, *args, **kwargs):
         client_batches = {}
-        end = []
+        failed = []
 
         for key, value in values.items():
             client = self._get_client(key)
 
             if client is None:
-                end.append(False)
+                failed.append(key)
                 continue
 
             if client.server not in client_batches:
@@ -261,11 +261,11 @@ class HashClient(object):
             new_args.insert(0, values)
             result = self._safely_run_func(
                 client,
-                client.set_many, False, *new_args, **kwargs
+                client.set_many, values.keys(), *new_args, **kwargs
             )
-            end.append(result)
+            failed.extend(result)
 
-        return all(end)
+        return failed
 
     set_multi = set_many
 

--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -257,13 +257,16 @@ class HashClient(object):
 
         for server, values in client_batches.items():
             client = self.clients['%s:%s' % server]
-            new_args = list(args)
-            new_args.insert(0, values)
-            result = self._safely_run_func(
-                client,
-                client.set_many, values.keys(), *new_args, **kwargs
-            )
-            failed.extend(result)
+
+            for value in values:
+                new_args = list(args)
+                new_args.insert(0, value)
+                result = self._safely_run_func(
+                    client,
+                    client.set, False, *new_args, **kwargs
+                )
+                if not result:
+                    failed.extend(result)
 
         return failed
 

--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -258,9 +258,10 @@ class HashClient(object):
         for server, values in client_batches.items():
             client = self.clients['%s:%s' % server]
 
-            for value in values:
+            for key, value in values.items():
                 new_args = list(args)
                 new_args.insert(0, value)
+                new_args.insert(0, key)
                 result = self._safely_run_func(
                     client,
                     client.set, False, *new_args, **kwargs

--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -267,7 +267,7 @@ class HashClient(object):
                     client.set, False, *new_args, **kwargs
                 )
                 if not result:
-                    failed.extend(result)
+                    failed.extend(key)
 
         return failed
 

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -752,8 +752,9 @@ class TestClient(ClientTestMixin, unittest.TestCase):
 
     def test_default_noreply_set_many(self):
         with pytest.raises(MemcacheUnknownError):
-            self._default_noreply_false(
-                'set_many', ({b'key': b'value'},), [b'NOT_STORED\r\n'])
+            client = self.make_client([b'UNKNOWN\r\n'], default_noreply=False)
+            result = client.set_many({b'key': b'value'})
+            assert result == [b'key']
         self._default_noreply_true_and_empty_list(
             'set_many', ({b'key': b'value'},), [b'NOT_STORED\r\n'])
 
@@ -873,8 +874,9 @@ class TestPooledClient(ClientTestMixin, unittest.TestCase):
 
     def test_default_noreply_set_many(self):
         with pytest.raises(MemcacheUnknownError):
-            self._default_noreply_false(
-                'set_many', ({b'key': b'value'},), [b'NOT_STORED\r\n'])
+            client = self.make_client([b'UNKNOWN\r\n'], default_noreply=False)
+            result = client.set_many({b'key': b'value'})
+            assert result == [b'key']
         self._default_noreply_true_and_empty_list(
             'set_many', ({b'key': b'value'},), [b'NOT_STORED\r\n'])
 
@@ -1018,5 +1020,5 @@ class TestRetryOnEINTR(unittest.TestCase):
             b'key1 0 6\r\nval',
             socket.error(errno.EINTR, "Interrupted system call"),
             b'ue1\r\nEND\r\n',
-            ])
+        ])
         assert client[b'key1'] == b'value1'

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -746,7 +746,9 @@ class TestClient(ClientTestMixin, unittest.TestCase):
     def test_default_noreply_set(self):
         with pytest.raises(MemcacheUnknownError):
             self._default_noreply_false(
-                'set', (b'key', b'value'), [b'NOT_STORED\r\n'])
+                'set', (b'key', b'value'), [b'UNKNOWN\r\n'])
+        self._default_noreply_false(
+            'set', (b'key', b'value'), [b'NOT_STORED\r\n'])
         self._default_noreply_true(
             'set', (b'key', b'value'), [b'NOT_STORED\r\n'])
 
@@ -868,15 +870,16 @@ class TestPooledClient(ClientTestMixin, unittest.TestCase):
     def test_default_noreply_set(self):
         with pytest.raises(MemcacheUnknownError):
             self._default_noreply_false(
-                'set', (b'key', b'value'), [b'NOT_STORED\r\n'])
+                'set', (b'key', b'value'), [b'UNKNOWN\r\n'])
+        self._default_noreply_false(
+            'set', (b'key', b'value'), [b'NOT_STORED\r\n'])
         self._default_noreply_true(
             'set', (b'key', b'value'), [b'NOT_STORED\r\n'])
 
     def test_default_noreply_set_many(self):
         with pytest.raises(MemcacheUnknownError):
             client = self.make_client([b'UNKNOWN\r\n'], default_noreply=False)
-            result = client.set_many({b'key': b'value'})
-            assert result == [b'key']
+            client.set_many({b'key': b'value'})
         self._default_noreply_true_and_empty_list(
             'set_many', ({b'key': b'value'},), [b'NOT_STORED\r\n'])
 

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -156,13 +156,13 @@ class ClientTestMixin(object):
     def test_set_many_success(self):
         client = self.make_client([b'STORED\r\n'])
         result = client.set_many({b'key': b'value'}, noreply=False)
-        assert result is True
+        assert result == []
 
     def test_set_multi_success(self):
         # Should just map to set_many
         client = self.make_client([b'STORED\r\n'])
         result = client.set_multi({b'key': b'value'}, noreply=False)
-        assert result is True
+        assert result == []
 
     def test_add_stored(self):
         client = self.make_client([b'STORED\r', b'\n'])
@@ -602,7 +602,7 @@ class TestClient(ClientTestMixin, unittest.TestCase):
     def test_set_many_socket_handling(self):
         client = self.make_client([b'STORED\r\n'])
         result = client.set_many({b'key': b'value'}, noreply=False)
-        assert result is True
+        assert result == []
         assert client.sock.closed is False
         assert len(client.sock.send_bufs) == 1
 
@@ -738,6 +738,11 @@ class TestClient(ClientTestMixin, unittest.TestCase):
         result = getattr(client, cmd)(*args)
         assert result is True
 
+    def _default_noreply_true_and_empty_list(self, cmd, args, response):
+        client = self.make_client(response, default_noreply=True)
+        result = getattr(client, cmd)(*args)
+        assert result == []
+
     def test_default_noreply_set(self):
         with pytest.raises(MemcacheUnknownError):
             self._default_noreply_false(
@@ -749,7 +754,7 @@ class TestClient(ClientTestMixin, unittest.TestCase):
         with pytest.raises(MemcacheUnknownError):
             self._default_noreply_false(
                 'set_many', ({b'key': b'value'},), [b'NOT_STORED\r\n'])
-        self._default_noreply_true(
+        self._default_noreply_true_and_empty_list(
             'set_many', ({b'key': b'value'},), [b'NOT_STORED\r\n'])
 
     def test_default_noreply_add(self):
@@ -854,6 +859,11 @@ class TestPooledClient(ClientTestMixin, unittest.TestCase):
         result = getattr(client, cmd)(*args)
         assert result is True
 
+    def _default_noreply_true_and_empty_list(self, cmd, args, response):
+        client = self.make_client(response, default_noreply=True)
+        result = getattr(client, cmd)(*args)
+        assert result == []
+
     def test_default_noreply_set(self):
         with pytest.raises(MemcacheUnknownError):
             self._default_noreply_false(
@@ -865,7 +875,7 @@ class TestPooledClient(ClientTestMixin, unittest.TestCase):
         with pytest.raises(MemcacheUnknownError):
             self._default_noreply_false(
                 'set_many', ({b'key': b'value'},), [b'NOT_STORED\r\n'])
-        self._default_noreply_true(
+        self._default_noreply_true_and_empty_list(
             'set_many', ({b'key': b'value'},), [b'NOT_STORED\r\n'])
 
     def test_default_noreply_add(self):

--- a/pymemcache/test/test_client_hash.py
+++ b/pymemcache/test/test_client_hash.py
@@ -235,18 +235,22 @@ class TestHashClient(ClientTestMixin, unittest.TestCase):
         assert len(result) == 2
 
     def test_noreply_set_many(self):
+        values = {
+            'key1': 'value1',
+            'key2': 'value2',
+            'key3': 'value3'
+        }
+
         client = self.make_client(*[
             [b'STORED\r\n', b'NOT_STORED\r\n', b'STORED\r\n'],
         ])
-        result = client.set_many(
-            {'key1': 'value1', 'key2': 'value2', 'key3': 'value3'}, noreply=False)
+        result = client.set_many(values, noreply=False)
         assert len(result) == 1
 
         client = self.make_client(*[
             [b'STORED\r\n', b'NOT_STORED\r\n', b'STORED\r\n'],
         ])
-        result = client.set_many(
-            {'key1': 'value1', 'key2': 'value2', 'key3': 'value3'}, noreply=True)
+        result = client.set_many(values, noreply=True)
         assert result == []
 
     # TODO: Test failover logic

--- a/pymemcache/test/test_client_hash.py
+++ b/pymemcache/test/test_client_hash.py
@@ -213,4 +213,40 @@ class TestHashClient(ClientTestMixin, unittest.TestCase):
         result = client.get_many(['foo', 'bar'])
         assert result == {'foo': False, 'bar': False}
 
+    def test_ignore_exec_set_many(self):
+        values = {
+            'key1': 'value1',
+            'key2': 'value2',
+            'key3': 'value3'
+        }
+
+        with pytest.raises(MemcacheUnknownError):
+            client = self.make_client(*[
+                [b'STORED\r\n', b'UNKNOWN\r\n', b'STORED\r\n'],
+                [b'STORED\r\n', b'UNKNOWN\r\n', b'STORED\r\n'],
+            ])
+            client.set_many(values, noreply=False)
+
+        client = self.make_client(*[
+            [b'STORED\r\n', b'UNKNOWN\r\n', b'STORED\r\n'],
+        ], ignore_exc=True)
+        result = client.set_many(values, noreply=False)
+
+        assert len(result) == 2
+
+    def test_noreply_set_many(self):
+        client = self.make_client(*[
+            [b'STORED\r\n', b'NOT_STORED\r\n', b'STORED\r\n'],
+        ])
+        result = client.set_many(
+            {'key1': 'value1', 'key2': 'value2', 'key3': 'value3'}, noreply=False)
+        assert len(result) == 1
+
+        client = self.make_client(*[
+            [b'STORED\r\n', b'NOT_STORED\r\n', b'STORED\r\n'],
+        ])
+        result = client.set_many(
+            {'key1': 'value1', 'key2': 'value2', 'key3': 'value3'}, noreply=True)
+        assert result == []
+
     # TODO: Test failover logic

--- a/pymemcache/test/test_client_hash.py
+++ b/pymemcache/test/test_client_hash.py
@@ -200,7 +200,7 @@ class TestHashClient(ClientTestMixin, unittest.TestCase):
         )
 
         result = client.set_many({'foo': 'bar'})
-        assert result is False
+        assert result == ['foo']
 
     def test_no_servers_left_with_get_many(self):
         from pymemcache.client.hash import HashClient

--- a/pymemcache/test/utils.py
+++ b/pymemcache/test/utils.py
@@ -105,7 +105,7 @@ class MockMemcacheClient(object):
     def set_many(self, values, expire=None, noreply=True):
         for key, value in six.iteritems(values):
             self.set(key, value, expire, noreply)
-        return True
+        return []
 
     set_multi = set_many
 


### PR DESCRIPTION
Failed `set_many` with django2.0.

```python
>>> from django.core.cache import cache
>>> cache.set_many({'aa': 1})
Traceback (most recent call last):
  File "/usr/lib/python3.6/code.py", line 91, in runcode
    exec(code, self.locals)
  File "<console>", line 1, in <module>
  File "/usr/local/lib/python3.6/dist-packages/ddtrace/contrib/django/cache.py", line 65, in wrapped
    return method(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/django_elastipymemcache/memcached.py", line 43, in wrapper
    return f(self, *args, **kwds)
  File "/usr/local/lib/python3.6/dist-packages/django_elastipymemcache/memcached.py", line 135, in set_many
    return super(ElastiPyMemCache, self).set_many(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/django/core/cache/backends/memcached.py", line 144, in set_many
    return [original_keys[k] for k in failed_keys]
TypeError: 'bool' object is not iterable
```

Release Note: https://docs.djangoproject.com/en/2.0/releases/2.0/#cache
Code: https://github.com/django/django/blob/338f741c5eb6b91118f6a6b7c34b5e9b47a5661d/django/core/cache/backends/memcached.py#L131-L139

Since django 2.0, the return value of set_many now expects a list of keys of failed objects in store.

It should be implemented at the cache backend, but python-memcached and pylibmc return list objects, so I tried it accordingly.