### PR TITLE
Split benchmarks by method and include get_multi and set_multi

### DIFF
--- a/pymemcache/test/conftest.py
+++ b/pymemcache/test/conftest.py
@@ -3,21 +3,20 @@ import socket
 
 
 def pytest_addoption(parser):
-    parser.addoption('--server', action='store',
-                     default='localhost',
+    parser.addoption('--server', action='store', default='localhost',
                      help='memcached server')
 
-    parser.addoption('--port', action='store',
-                     default='11211',
+    parser.addoption('--port', action='store', default='11211',
                      help='memcached server port')
 
-    parser.addoption('--size', action='store',
-                     default=1024,
+    parser.addoption('--size', action='store', default=1024,
                      help='size of data in benchmarks')
 
-    parser.addoption('--count', action='store',
-                     default=10000,
-                     help='amount of values to use in  benchmarks')
+    parser.addoption('--count', action='store', default=10000,
+                     help='number of iterations to run each benchmark')
+
+    parser.addoption('--keys', action='store', default=20,
+                     help='number of keys to use for multi benchmarks')
 
 
 @pytest.fixture(scope='session')
@@ -38,6 +37,16 @@ def size(request):
 @pytest.fixture(scope='session')
 def count(request):
     return int(request.config.option.count)
+
+
+@pytest.fixture(scope='session')
+def keys(request):
+    return int(request.config.option.keys)
+
+
+@pytest.fixture(scope='session')
+def pairs(size, keys):
+    return {'pymemcache_test:%d' % i: 'X' * size for i in range(keys)}
 
 
 def pytest_generate_tests(metafunc):


### PR DESCRIPTION
The current benchmarks are fairly coarse and make it difficult to tell which methods are performant and which could use some work. This diff breaks them down more comprehensively and adds in `get_multi()` and `set_multi()` tests. Beware that these are slow (particularly on pylibmc).

Example output:
```
$ pytest --verbose --capture=no --no-cov -m benchmark pymemcache/test
================================================ test session starts =================================================
platform darwin -- Python 2.7.15, pytest-3.7.4, py-1.6.0, pluggy-0.7.1 -- /Users/shargan/repos/pymemcache/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/shargan/repos/pymemcache, inifile: setup.cfg
plugins: cov-2.5.1
collected 392 items / 380 deselected

pymemcache/test/test_benchmark.py::test_bench_get[pylibmc] 3.96473503113
PASSED
pymemcache/test/test_benchmark.py::test_bench_get[memcache] 3.47158002853
PASSED
pymemcache/test/test_benchmark.py::test_bench_get[pymemcache] 3.10178208351
PASSED
pymemcache/test/test_benchmark.py::test_bench_set[pylibmc] 2.78271698952
PASSED
pymemcache/test/test_benchmark.py::test_bench_set[memcache] 2.81442403793
PASSED
pymemcache/test/test_benchmark.py::test_bench_set[pymemcache] 0.337506771088
PASSED
pymemcache/test/test_benchmark.py::test_bench_get_multi[pylibmc] 3.44503307343
PASSED
pymemcache/test/test_benchmark.py::test_bench_get_multi[memcache] 7.20358395576
PASSED
pymemcache/test/test_benchmark.py::test_bench_get_multi[pymemcache] 6.60911607742
PASSED
pymemcache/test/test_benchmark.py::test_bench_set_multi[pylibmc] 50.6990809441
PASSED
pymemcache/test/test_benchmark.py::test_bench_set_multi[memcache] 7.8389480114
PASSED
pymemcache/test/test_benchmark.py::test_bench_set_multi[pymemcache] 7.2995929718
PASSED
WARNING: Coverage disabled via --no-cov switch!

================================================== warnings summary ==================================================
<undetermined location>
  Coverage disabled via --no-cov switch!

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=============================== 12 passed, 380 deselected, 1 warnings in 99.86 seconds ===============================
```

Using [pytest.benchmark](https://github.com/ionelmc/pytest-benchmark) would eliminate some of the complexity here and helps control the amount of time permitted to each benchmark, but I was hesitant to add a new external dependency and so dramatically change the resulting format.