### PR TITLE
Remove py26 detritus from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ cache:
 language: python
 matrix:
   include:
-    - python: 2.6
-      env: TOXENV=py26
     - python: 2.7
       env: TOXENV=py27,py27-flake8
     - python: 3.4


### PR DESCRIPTION
Python 2.6 support was killed in https://github.com/pinterest/pymemcache/pull/142 but it looks like Travis is still trying to run tests against the py26 Tox environment (failing https://github.com/pinterest/pymemcache/pull/180, for example).