### PR TITLE
Properly batch Client.set_many() calls

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -788,12 +788,11 @@ class Client(object):
                 extra += b' noreply'
 
             cmds.append(name + b' ' + key + b' ' +
-                   six.text_type(flags).encode('ascii') +
-                   b' ' + six.text_type(expire).encode('ascii') +
-                   b' ' + six.text_type(len(data)).encode('ascii') + extra +
-                   b'\r\n' + data + b'\r\n')
+                        six.text_type(flags).encode('ascii') +
+                        b' ' + six.text_type(expire).encode('ascii') +
+                        b' ' + six.text_type(len(data)).encode('ascii') +
+                        extra + b'\r\n' + data + b'\r\n')
 
-        # TODO: behavior appears untested
         if not self.sock:
             self._connect()
 

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -15,7 +15,9 @@
 
 import collections
 import errno
+import functools
 import json
+import mock
 import socket
 import unittest
 import pytest
@@ -85,7 +87,12 @@ class MockSocketModule(object):
 class ClientTestMixin(object):
     def make_client(self, mock_socket_values, **kwargs):
         client = Client(None, **kwargs)
-        client.sock = MockSocket(list(mock_socket_values))
+        # mock out client._connect() rather than hard-settting client.sock to
+        # ensure methods are checking whether self.sock is None before
+        # attempting to use it
+        sock = MockSocket(list(mock_socket_values))
+        client._connect = mock.Mock(side_effect=functools.partial(
+            setattr, client, "sock", sock))
         return client
 
     def test_set_success(self):


### PR DESCRIPTION
`pymemcache.client.base.Client.set_many()` currently loops over its `values` dictionary and sends each key-value pair separately rather. This diff drops them in bulk into the fewest TCP packets in which they'll fit. If the overall approach meets your approval, I'll send a separate PR to do the same for `delete_many()`.

Using the expanded benchmarks from #180 and snipping output down to just the relevant lines, the current codebase yields these results:
```
# python2.7
$ pytest --verbose --capture=no --no-cov -m benchmark pymemcache/test --keys 100 --count 10000
========================================== test session starts ===========================================
platform darwin -- Python 2.7.15, pytest-3.7.4, py-1.6.0, pluggy-0.7.1 -- /Users/shargan/repos/pymemcache/.venv/bin/python

pymemcache/test/test_benchmark.py::test_bench_set[pymemcache] 0.449674129486
pymemcache/test/test_benchmark.py::test_bench_set_multi[pymemcache] 36.8027918339


# python3.6
$ pytest --verbose --capture=no --no-cov -m benchmark pymemcache/test --keys 100 --count 10000
========================================== test session starts ===========================================
platform darwin -- Python 3.6.6, pytest-3.7.4, py-1.6.0, pluggy-0.7.1 -- /Users/shargan/repos/pymemcache/.venv36/bin/python3.6

pymemcache/test/test_benchmark.py::test_bench_set[pymemcache] 0.3536701202392578
pymemcache/test/test_benchmark.py::test_bench_set_multi[pymemcache] 35.68993163108826
```

With this diff applied, the results show increased `set_multi` throughput:
```
# python2.7
$ pytest --verbose --capture=no --no-cov -m benchmark pymemcache/test --keys 100 --count 10000
========================================== test session starts ===========================================
platform darwin -- Python 2.7.15, pytest-3.7.4, py-1.6.0, pluggy-0.7.1 -- /Users/shargan/repos/pymemcache/.venv/bin/python

pymemcache/test/test_benchmark.py::test_bench_set[pymemcache] 0.389505147934
pymemcache/test/test_benchmark.py::test_bench_set_multi[pymemcache] 10.9233689308


# python3.6
$ pytest --verbose --capture=no --no-cov -m benchmark pymemcache/test --keys 100 --count 10000
========================================== test session starts ===========================================
platform darwin -- Python 3.6.6, pytest-3.7.4, py-1.6.0, pluggy-0.7.1 -- /Users/shargan/repos/pymemcache/.venv36/bin/python3.6

pymemcache/test/test_benchmark.py::test_bench_set[pymemcache] 0.38876795768737793
pymemcache/test/test_benchmark.py::test_bench_set_multi[pymemcache] 11.447095155715942
```

This has the added side effect of allowing future revisions to add `X_many()` sister methods to any of the other storage commands.