### PR TITLE
Improve _check_key() and _store_cmd() performance

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -90,29 +90,19 @@ def _check_key(key, allow_unicode_keys, key_prefix=b''):
         try:
             key = key.encode('ascii')
         except (UnicodeEncodeError, UnicodeDecodeError):
-            raise MemcacheIllegalInputError("Non-ASCII key: '%r'" % (key,))
+            raise MemcacheIllegalInputError("Non-ASCII key: '%r'" % key)
+
     key = key_prefix + key
+    parts = key.split()
 
     if len(key) > 250:
-        raise MemcacheIllegalInputError("Key is too long: '%r'" % (key,))
+        raise MemcacheIllegalInputError("Key is too long: '%r'" % key)
+    # second statement catches leading or trailing whitespace
+    elif len(parts) > 1 or parts[0] != key:
+        raise MemcacheIllegalInputError("Key contains whitespace: '%r'" % key)
+    elif b'\00' in key:
+        raise MemcacheIllegalInputError("Key contains null: '%r'" % key)
 
-    for c in bytearray(key):
-        if c == ord(b' '):
-            raise MemcacheIllegalInputError(
-                "Key contains space: '%r'" % (key,)
-            )
-        elif c == ord(b'\n'):
-            raise MemcacheIllegalInputError(
-                "Key contains newline: '%r'" % (key,)
-            )
-        elif c == ord(b'\00'):
-            raise MemcacheIllegalInputError(
-                "Key contains null character: '%r'" % (key,)
-            )
-        elif c == ord(b'\r'):
-            raise MemcacheIllegalInputError(
-                "Key contains carriage return: '%r'" % (key,)
-            )
     return key
 
 

--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -755,6 +755,14 @@ class Client(object):
     def _store_cmd(self, name, values, expire, noreply, cas=None):
         cmds = []
         keys = []
+
+        extra = b''
+        if cas is not None:
+            extra += b' ' + cas
+        if noreply:
+            extra += b' noreply'
+        expire = six.text_type(expire).encode('ascii')
+
         for key, data in six.iteritems(values):
             # must be able to reliably map responses back to the original order
             keys.append(key)
@@ -771,15 +779,9 @@ class Client(object):
                 except UnicodeEncodeError as e:
                     raise MemcacheIllegalInputError(str(e))
 
-            extra = b''
-            if cas is not None:
-                extra += b' ' + cas
-            if noreply:
-                extra += b' noreply'
-
             cmds.append(name + b' ' + key + b' ' +
                         six.text_type(flags).encode('ascii') +
-                        b' ' + six.text_type(expire).encode('ascii') +
+                        b' ' + expire +
                         b' ' + six.text_type(len(data)).encode('ascii') +
                         extra + b'\r\n' + data + b'\r\n')
 


### PR DESCRIPTION
While making the batching changes in #182 I noticed a few performance hot-spots.

1. `_check_key()` is called at least once on every single operation and was doing a lot of repeat or just inefficient work.
2. `_store_cmd()` was calculating and encoding `extra` and `expire` for every key/value pair even though they don't change (I didn't move this in the previous PR because I didn't want to muddy my intentions).

The first change is responsible for most of the performance increase, it affects every method, and the difference scales with key length. The second only impacts `set_many()` but in my 100-key tests was responsible for a decent 7.5% gain.

Benchmarks from master with irrelevant lines trimmed:
```
# python2.7
$ pytest --verbose --capture=no --no-cov -m benchmark pymemcache/test --keys 100 --count 10000
================================================ test session starts =================================================
platform darwin -- Python 2.7.15, pytest-3.7.4, py-1.6.0, pluggy-0.7.1 -- /Users/shargan/repos/pymemcache/.venv/bin/python

pymemcache/test/test_benchmark.py::test_bench_get[pymemcache] 2.37730312347
pymemcache/test/test_benchmark.py::test_bench_set[pymemcache] 0.353810071945
pymemcache/test/test_benchmark.py::test_bench_get_multi[pymemcache] 16.3643598557
pymemcache/test/test_benchmark.py::test_bench_set_multi[pymemcache] 10.8592970371


# python3.6
$ pytest --verbose --capture=no --no-cov -m benchmark pymemcache/test --keys 100 --count 10000
================================================ test session starts =================================================
platform darwin -- Python 3.6.6, pytest-3.7.4, py-1.6.0, pluggy-0.7.1 -- /Users/shargan/repos/pymemcache/.venv36/bin/python3.6

pymemcache/test/test_benchmark.py::test_bench_get[pymemcache] 3.1345767974853516
pymemcache/test/test_benchmark.py::test_bench_set[pymemcache] 0.3885829448699951
pymemcache/test/test_benchmark.py::test_bench_get_multi[pymemcache] 18.19443702697754
pymemcache/test/test_benchmark.py::test_bench_set_multi[pymemcache] 11.366436004638672
```

With this diff:
```
# python2.7
$ pytest --verbose --capture=no --no-cov -m benchmark pymemcache/test --keys 100 --count 10000
================================================ test session starts =================================================
platform darwin -- Python 2.7.15, pytest-3.7.4, py-1.6.0, pluggy-0.7.1 -- /Users/shargan/repos/pymemcache/.venv/bin/python

pymemcache/test/test_benchmark.py::test_bench_get[pymemcache] 2.65929102898
pymemcache/test/test_benchmark.py::test_bench_set[pymemcache] 0.332684993744
pymemcache/test/test_benchmark.py::test_bench_get_multi[pymemcache] 12.0730199814
pymemcache/test/test_benchmark.py::test_bench_set_multi[pymemcache] 5.42873597145


# python3.6
$ pytest --verbose --capture=no --no-cov -m benchmark pymemcache/test --keys 100 --count 10000
================================================ test session starts =================================================
platform darwin -- Python 3.6.6, pytest-3.7.4, py-1.6.0, pluggy-0.7.1 -- /Users/shargan/repos/pymemcache/.venv36/bin/python3.6

pymemcache/test/test_benchmark.py::test_bench_get[pymemcache] 2.7322170734405518
pymemcache/test/test_benchmark.py::test_bench_set[pymemcache] 0.32326221466064453
pymemcache/test/test_benchmark.py::test_bench_get_multi[pymemcache] 11.463497877120972
pymemcache/test/test_benchmark.py::test_bench_set_multi[pymemcache] 6.002143859863281
```