### PR TITLE
Properly batch Client.delete_many() calls

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -502,10 +502,10 @@ class Client(object):
         if noreply:
             cmd += b' noreply'
         cmd += b'\r\n'
-        result = self._misc_cmd(cmd, b'delete', noreply)
+        results = self._misc_cmd([cmd], b'delete', noreply)
         if noreply:
             return True
-        return result == b'DELETED'
+        return results[0] == b'DELETED'
 
     def delete_many(self, keys, noreply=None):
         """
@@ -528,11 +528,13 @@ class Client(object):
         if noreply is None:
             noreply = self.default_noreply
 
-        # TODO: make this more performant by sending all keys first, then
-        # waiting for all values.
+        cmds = []
         for key in keys:
-            self.delete(key, noreply)
-
+            cmds.append(
+                b'delete ' + self.check_key(key) +
+                (b' noreply' if noreply else b'') +
+                b'\r\n')
+        self._misc_cmd(cmds, b'delete', noreply)
         return True
 
     delete_multi = delete_many
@@ -555,12 +557,12 @@ class Client(object):
         if noreply:
             cmd += b' noreply'
         cmd += b'\r\n'
-        result = self._misc_cmd(cmd, b'incr', noreply)
+        results = self._misc_cmd([cmd], b'incr', noreply)
         if noreply:
             return None
-        if result == b'NOT_FOUND':
+        if results[0] == b'NOT_FOUND':
             return None
-        return int(result)
+        return int(results[0])
 
     def decr(self, key, value, noreply=False):
         """
@@ -580,12 +582,12 @@ class Client(object):
         if noreply:
             cmd += b' noreply'
         cmd += b'\r\n'
-        result = self._misc_cmd(cmd, b'decr', noreply)
+        results = self._misc_cmd([cmd], b'decr', noreply)
         if noreply:
             return None
-        if result == b'NOT_FOUND':
+        if results[0] == b'NOT_FOUND':
             return None
-        return int(result)
+        return int(results[0])
 
     def touch(self, key, expire=0, noreply=None):
         """
@@ -609,10 +611,10 @@ class Client(object):
         if noreply:
             cmd += b' noreply'
         cmd += b'\r\n'
-        result = self._misc_cmd(cmd, b'touch', noreply)
+        results = self._misc_cmd([cmd], b'touch', noreply)
         if noreply:
             return True
-        return result == b'TOUCHED'
+        return results[0] == b'TOUCHED'
 
     def stats(self, *args):
         """
@@ -648,13 +650,13 @@ class Client(object):
             A string of the memcached version.
         """
         cmd = b"version\r\n"
-        result = self._misc_cmd(cmd, b'version', False)
+        results = self._misc_cmd([cmd], b'version', False)
+        before, _, after = results[0].partition(b' ')
 
-        if not result.startswith(b'VERSION '):
+        if before != b'VERSION':
             raise MemcacheUnknownError(
-                "Received unexpected response: %s" % (result, ))
-
-        return result[8:]
+                "Received unexpected response: %s" % results[0])
+        return after
 
     def flush_all(self, delay=0, noreply=None):
         """
@@ -675,10 +677,10 @@ class Client(object):
         if noreply:
             cmd += b' noreply'
         cmd += b'\r\n'
-        result = self._misc_cmd(cmd, b'flush_all', noreply)
+        results = self._misc_cmd([cmd], b'flush_all', noreply)
         if noreply:
             return True
-        return result == b'OK'
+        return results[0] == b'OK'
 
     def quit(self):
         """
@@ -689,7 +691,7 @@ class Client(object):
         be re-used after quit.
         """
         cmd = b"quit\r\n"
-        self._misc_cmd(cmd, b'quit', True)
+        self._misc_cmd([cmd], b'quit', True)
         self.close()
 
     def _raise_errors(self, line, name):
@@ -823,20 +825,24 @@ class Client(object):
             self.close()
             raise
 
-    def _misc_cmd(self, cmd, cmd_name, noreply):
+    def _misc_cmd(self, cmds, cmd_name, noreply):
         if not self.sock:
             self._connect()
 
         try:
-            self.sock.sendall(cmd)
+            self.sock.sendall(b''.join(cmds))
 
             if noreply:
-                return
+                return []
 
-            _, line = _readline(self.sock, b'')
-            self._raise_errors(line, cmd_name)
+            results = []
+            buf = b''
+            for cmd in cmds:
+                buf, line = _readline(self.sock, buf)
+                self._raise_errors(line, cmd_name)
+                results.append(line)
+            return results
 
-            return line
         except Exception:
             self.close()
             raise

--- a/pymemcache/test/test_benchmark.py
+++ b/pymemcache/test/test_benchmark.py
@@ -99,3 +99,14 @@ def test_bench_get_multi(request, client, pairs, count):
 @pytest.mark.benchmark()
 def test_bench_set_multi(request, client, pairs, count):
     benchmark(count, client.set_multi, pairs)
+
+
+@pytest.mark.benchmark()
+def test_bench_delete(request, client, pairs, count):
+    benchmark(count, client.delete, six.next(six.iterkeys(pairs)))
+
+
+@pytest.mark.benchmark()
+def test_bench_delete_multi(request, client, pairs, count):
+    # deleting missing key takes the same work client-side as real keys
+    benchmark(count, client.delete_multi, list(pairs))


### PR DESCRIPTION
Essentially the same change as #182 but for `delete_many()` and its underlying `_misc_cmd()` method. This includes benchmarks for the delete methods.

Benchmarks for the current codebase with irrelevant lines trimmed:
```
# python2.7
$ pytest --verbose --capture=no --no-cov -m benchmark pymemcache/test --keys 100 --count 10000
================================================ test session starts =================================================
platform darwin -- Python 2.7.15, pytest-3.7.4, py-1.6.0, pluggy-0.7.1 -- /Users/shargan/repos/pymemcache/.venv/bin/python

pymemcache/test/test_benchmark.py::test_bench_delete[pymemcache] 0.296519994736
pymemcache/test/test_benchmark.py::test_bench_delete_multi[pymemcache] 27.9956350327


# python3.6
$ pytest --verbose --capture=no --no-cov -m benchmark pymemcache/test --keys 100 --count 10000
================================================= test session starts =================================================
platform darwin -- Python 3.6.6, pytest-3.7.4, py-1.6.0, pluggy-0.7.1 -- /Users/shargan/repos/pymemcache/.venv36/bin/python3.6

pymemcache/test/test_benchmark.py::test_bench_delete[pymemcache] 0.2534470558166504
pymemcache/test/test_benchmark.py::test_bench_delete_multi[pymemcache] 25.861117839813232
```

With this diff applied, `delete_multi()` is significantly improved:
```
# python2.7
$ pytest --verbose --capture=no --no-cov -m benchmark pymemcache/test --keys 100 --count 10000
================================================ test session starts =================================================
platform darwin -- Python 2.7.15, pytest-3.7.4, py-1.6.0, pluggy-0.7.1 -- /Users/shargan/repos/pymemcache/.venv/bin/python

pymemcache/test/test_benchmark.py::test_bench_delete[pymemcache] 0.310829877853
pymemcache/test/test_benchmark.py::test_bench_delete_multi[pymemcache] 5.40752792358


# python3.6
$ pytest --verbose --capture=no --no-cov -m benchmark pymemcache/test --keys 100 --count 10000
================================================= test session starts =================================================
platform darwin -- Python 3.6.6, pytest-3.7.4, py-1.6.0, pluggy-0.7.1 -- /Users/shargan/repos/pymemcache/.venv36/bin/python3.6

pymemcache/test/test_benchmark.py::test_bench_delete[pymemcache] 0.30205321311950684
pymemcache/test/test_benchmark.py::test_bench_delete_multi[pymemcache] 6.920046091079712
```