### PR TITLE
Use simpler Travis pip caching syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 sudo: false
-cache:
-  directories:
-    - $HOME/.cache/pip
+cache: pip
 language: python
 matrix:
   include:


### PR DESCRIPTION
The previous directory-based caching directive worked fine, but using
the generic `pip` syntax is simpler and more future-proof.