### PR TITLE
Add official Python 3.7 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ env/
 
 # Unit test / coverage reports
 .coverage
+.pytest_cache
 .tox
 
 #Translations

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,11 @@ matrix:
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6
-      env: TOXENV=py36,py36-flake8
+      env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37,py37-flake8
+      dist: xenial
+      sudo: true
     - python: pypy
       env: TOXENV=pypy
     - python: pypy3

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: PyPy',
         'License :: OSI Approved :: Apache Software License',
         'Topic :: Database',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 mock
 pytest
 pytest-cov
-gevent==1.1; "PyPy" not in platform_python_implementation
+gevent==1.3; "PyPy" not in platform_python_implementation
 pylibmc
 python-memcached

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 mock
 pytest
 pytest-cov
-gevent==1.3; "PyPy" not in platform_python_implementation
+gevent==1.3.6; "PyPy" not in platform_python_implementation
 pylibmc
 python-memcached

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, pypy, pypy3, py27-flake8, py36-flake8, integration
+envlist = py27, py34, py35, py36, py37, pypy, pypy3, py27-flake8, py37-flake8, integration
 skip_missing_interpreters = True
 
 [testenv]
@@ -19,7 +19,7 @@ commands =
     pip install flake8
     flake8 pymemcache/
 
-[testenv:py36-flake8]
+[testenv:py37-flake8]
 commands =
     pip install flake8
     flake8 pymemcache/


### PR DESCRIPTION
Travis's default base image doesn't support Python 3.7 very well so we
need to explicitly select the xenial distribution with sudo enabled.