### PR TITLE
Fix support newbytes from future

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -88,7 +88,10 @@ def _check_key(key, allow_unicode_keys, key_prefix=b''):
             key = key.encode('utf8')
     elif isinstance(key, VALID_STRING_TYPES):
         try:
-            key = key.encode('ascii')
+            if isinstance(key, bytes):
+                key = key.decode().encode('ascii')
+            else:
+                key = key.encode('ascii')
         except (UnicodeEncodeError, UnicodeDecodeError):
             raise MemcacheIllegalInputError("Non-ASCII key: '%r'" % key)
 

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from builtins import bytes as newbytes
+
 import collections
 import errno
 import functools
@@ -98,6 +100,11 @@ class ClientTestMixin(object):
     def test_set_success(self):
         client = self.make_client([b'STORED\r\n'])
         result = client.set(b'key', b'value', noreply=False)
+        assert result is True
+
+    def test_set_future(self):
+        client = self.make_client([b'STORED\r\n'])
+        result = client.set(newbytes(b'key'), newbytes(b'value'), noreply=False)
         assert result is True
 
     def test_set_unicode_key(self):

--- a/pymemcache/test/test_integration.py
+++ b/pymemcache/test/test_integration.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from builtins import bytes as newbytes
+
 from collections import defaultdict
 import json
 import pytest
@@ -57,6 +59,18 @@ def test_get_set(client_class, host, port, socket_module):
     value = b'value'
     key2 = b'key2'
     value2 = b'value2'
+    get_set_helper(client, key, value, key2, value2)
+
+
+@pytest.mark.integration()
+def test_get_set_newbytes(client_class, host, port, socket_module):
+    client = client_class((host, port), socket_module=socket_module)
+    client.flush_all()
+
+    key = newbytes(b'key3')
+    value = b'value3'
+    key2 = newbytes(b'key4')
+    value2 = b'value4'
     get_set_helper(client, key, value, key2, value2)
 
 

--- a/pymemcache/test/utils.py
+++ b/pymemcache/test/utils.py
@@ -48,7 +48,10 @@ class MockMemcacheClient(object):
                 raise MemcacheIllegalInputError(key)
             if isinstance(key, six.string_types):
                 try:
-                    key = key.encode('ascii')
+                    if isinstance(key, bytes):
+                        key = key.decode().encode('ascii')
+                    else:
+                        key = key.encode('ascii')
                 except (UnicodeEncodeError, UnicodeDecodeError):
                     raise MemcacheIllegalInputError
 
@@ -80,7 +83,10 @@ class MockMemcacheClient(object):
                 raise MemcacheIllegalInputError(key)
             if isinstance(key, six.string_types):
                 try:
-                    key = key.encode('ascii')
+                    if isinstance(key, bytes):
+                        key = key.decode().encode('ascii')
+                    else:
+                        key = key.encode('ascii')
                 except (UnicodeEncodeError, UnicodeDecodeError):
                     raise MemcacheIllegalInputError
         if isinstance(value, six.text_type):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,4 @@ pytest-cov
 gevent==1.3.6; "PyPy" not in platform_python_implementation
 pylibmc
 python-memcached
+future


### PR DESCRIPTION
Previously python2 code using python-future to backport the py3 bytes
behavior would trigger the following exception:


code:
```python
from builtins import bytes as newbytes
from pymemcache.client.base import Client
client = Client(('localhost', 11211))
client.set(newbytes('key'), 'value')
```

Output:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/site-packages/pymemcache/client/base.py", line 297, in set
    return self._store_cmd(b'set', key, expire, noreply, value)
  File "/usr/local/lib/python2.7/site-packages/pymemcache/client/base.py", line 770, in _store_cmd
    key = self.check_key(key)
  File "/usr/local/lib/python2.7/site-packages/pymemcache/client/base.py", line 251, in check_key
    key_prefix=self.key_prefix)
  File "/usr/local/lib/python2.7/site-packages/pymemcache/client/base.py", line 91, in _check_key
    key = key.encode('ascii')
  File "/usr/local/lib/python2.7/site-packages/future/types/newbytes.py", line 381, in __getattribute__
    raise AttributeError("encode method has been disabled in newbytes")
AttributeError: encode method has been disabled in newbytes
```

Add a test case for this and fix.