### PR TITLE
Clean up some changelog links

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,13 +2,13 @@ Change Log
 ==========
 New in version 2.0.0
 --------------------
-* Change set_many and set_multi api return value. `PR#179 <https://github.com/pinterest/pymemcache/pull/179>`_
-* Fix support for newbytes from python-future. `PR#187 <https://github.com/pinterest/pymemcache/pull/187>`_
+* Change set_many and set_multi api return value. `#179 <https://github.com/pinterest/pymemcache/pull/179>`_
+* Fix support for newbytes from python-future. `#187 <https://github.com/pinterest/pymemcache/pull/187>`_
 * Add support for Python 3.7, and drop support for Python 3.3
-* Properly batch Client.set_many() call. `PR#182 <https://github.com/pinterest/pymemcache/pull/182>`_
-* Improve _check_key() and _store_cmd() performance.  `PR#183 <https://github.com/pinterest/pymemcache/pull/183>`_
-* Properly batch Client.delete_many() call. `PR#184 <https://github.com/pinterest/pymemcache/pull/184>`_
-* Add option to explicitly set pickle version used by serde. `PR#190 <https://github.com/pinterest/pymemcache/pull/190>`_
+* Properly batch Client.set_many() call. `#182 <https://github.com/pinterest/pymemcache/pull/182>`_
+* Improve _check_key() and _store_cmd() performance. `#183 <https://github.com/pinterest/pymemcache/pull/183>`_
+* Properly batch Client.delete_many() call. `#184 <https://github.com/pinterest/pymemcache/pull/184>`_
+* Add option to explicitly set pickle version used by serde. `#190 <https://github.com/pinterest/pymemcache/pull/190>`_
 
 New in version 1.4.4
 --------------------
@@ -16,7 +16,7 @@ New in version 1.4.4
 * full benchmarks in test
 * fix flake8 issues
 * Have mockmemcacheclient support non-ascii strings
-* Switch from using pickle format 0 to the highest available version. See `PR#156 <https://github.com/pinterest/pymemcache/pull/156>`_
+* Switch from using pickle format 0 to the highest available version. See `#156 <https://github.com/pinterest/pymemcache/pull/156>`_
 
   *Warning*: different versions of python have different highest pickle versions: https://docs.python.org/3/library/pickle.html
 
@@ -24,16 +24,16 @@ New in version 1.4.4
 New in version 1.4.3
 --------------------
 * Documentation improvements
-* Fixed cachedump stats command, see `ticket <https://github.com/pinterest/pymemcache/issues/103>`_
+* Fixed cachedump stats command, see `#103 <https://github.com/pinterest/pymemcache/issues/103>`_
 * Honor default_value in HashClient
 
 New in version 1.4.2
 --------------------
-* Drop support for python 2.6, see `ticket <https://github.com/pinterest/pymemcache/issues/139>`_
+* Drop support for python 2.6, see `#109 <https://github.com/pinterest/pymemcache/issues/139>`_
 
 New in version 1.4.1
 --------------------
-* Python 3 serializations `fixes <https://github.com/pinterest/pymemcache/pull/131>`_
+* Python 3 serializations fixes `#131 <https://github.com/pinterest/pymemcache/pull/131>`_
 * Drop support for pypy3
 * Comment cleanup
 * Add gets_many to hash_client


### PR DESCRIPTION
There were some duplicate link targets in here that produced
reStructuredText errors.