### PR TITLE
Allow classes, functions, exceptions to be conveniently imported from the package.

### DIFF
--- a/pymemcache/__init__.py
+++ b/pymemcache/__init__.py
@@ -3,3 +3,11 @@ __author__ = "Charles Gordon"
 
 from pymemcache.client import Client  # noqa
 from pymemcache.client import PooledClient  # noqa
+
+from pymemcache.exceptions import MemcacheError  # noqa
+from pymemcache.exceptions import MemcacheClientError  # noqa
+from pymemcache.exceptions import MemcacheUnknownCommandError  # noqa
+from pymemcache.exceptions import MemcacheIllegalInputError  # noqa
+from pymemcache.exceptions import MemcacheServerError  # noqa
+from pymemcache.exceptions import MemcacheUnknownError  # noqa
+from pymemcache.exceptions import MemcacheUnexpectedCloseError  # noqa

--- a/pymemcache/__init__.py
+++ b/pymemcache/__init__.py
@@ -1,13 +1,5 @@
 __version__ = '2.0.0'
 __author__ = "Charles Gordon"
 
-from pymemcache.client import Client  # noqa
-from pymemcache.client import PooledClient  # noqa
-
-from pymemcache.exceptions import MemcacheError  # noqa
-from pymemcache.exceptions import MemcacheClientError  # noqa
-from pymemcache.exceptions import MemcacheUnknownCommandError  # noqa
-from pymemcache.exceptions import MemcacheIllegalInputError  # noqa
-from pymemcache.exceptions import MemcacheServerError  # noqa
-from pymemcache.exceptions import MemcacheUnknownError  # noqa
-from pymemcache.exceptions import MemcacheUnexpectedCloseError  # noqa
+from pymemcache.client.base import Client  # noqa
+from pymemcache.client.base import PooledClient  # noqa

--- a/pymemcache/__init__.py
+++ b/pymemcache/__init__.py
@@ -1,2 +1,5 @@
 __version__ = '2.0.0'
 __author__ = "Charles Gordon"
+
+from pymemcache.client import Client  # noqa
+from pymemcache.client import PooledClient  # noqa

--- a/pymemcache/__init__.py
+++ b/pymemcache/__init__.py
@@ -3,3 +3,11 @@ __author__ = "Charles Gordon"
 
 from pymemcache.client.base import Client  # noqa
 from pymemcache.client.base import PooledClient  # noqa
+
+from pymemcache.exceptions import MemcacheError  # noqa
+from pymemcache.exceptions import MemcacheClientError  # noqa
+from pymemcache.exceptions import MemcacheUnknownCommandError  # noqa
+from pymemcache.exceptions import MemcacheIllegalInputError  # noqa
+from pymemcache.exceptions import MemcacheServerError  # noqa
+from pymemcache.exceptions import MemcacheUnknownError  # noqa
+from pymemcache.exceptions import MemcacheUnexpectedCloseError  # noqa


### PR DESCRIPTION
The PR allows package level import
```python
from pymemcache import Client, PooledClient, MemcacheError, ...
```

Currently its
```python

from pymemcache.client.base import Client, PooledClient
or 
from pymemcache.client import Client, MemcacheError
```