### PR TITLE
Remove 'sudo: false' from Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 cache: pip
 language: python
 matrix:


### PR DESCRIPTION
This is in preparation for the Linux Infrastructure Migration:

https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration