### PR TITLE
Add UNIX domain socket support

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -6,6 +6,8 @@ New in version 2.1.0
 * Public classes and exceptions can now be imported from the top-level
   ``pymemcache`` package (e.g. ``pymemcache.Client``).
   `#197 <https://github.com/pinterest/pymemcache/pull/197>`_
+* Add UNIX domain socket support and document server connection options.
+  `#206 <https://github.com/pinterest/pymemcache/pull/206>`_
   
 New in version 2.0.0
 --------------------

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -13,6 +13,17 @@ Basic Usage
     client.set('some_key', 'some_value')
     result = client.get('some_key')
 
+Using UNIX domain sockets
+-------------------------
+You can also connect to a local memcached server over a UNIX domain socket by
+passing the socket's path to the client's ``server`` parameter:
+
+.. code-block:: python
+
+    from pymemcache.client.base import Client
+
+    client = Client('/var/run/memcached/memcached.sock')
+
 Using a memcached cluster
 -------------------------
 This will use a consistent hashing algorithm to choose which server to


### PR DESCRIPTION
The client's `server` argument can now be a string containing the path
to the memcached server's UNIX domain socket.

Also document all of the connection-oriented client parameters.

This builds on the earlier work proposed in #162 and #196.