### PR TITLE
Add support for the 'cache_memlimit' command

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -660,6 +660,20 @@ class Client(object):
 
         return result
 
+    def cache_memlimit(self, memlimit):
+        """
+        The memcached "cache_memlimit" command.
+
+        Args:
+            A number of megabytes to set as the new memlimit
+
+        Returns:
+          If no exception is raised, always returns True.
+        """
+
+        self._fetch_cmd(b'cache_memlimit', [str(int(memlimit))], False)
+        return True
+
     def version(self):
         """
         The memcached "version" command.
@@ -742,7 +756,7 @@ class Client(object):
             while True:
                 buf, line = _readline(self.sock, buf)
                 self._raise_errors(line, name)
-                if line == b'END':
+                if line == b'END' or line == b'OK':
                     return result
                 elif line.startswith(b'VALUE'):
                     if expect_cas:

--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -665,7 +665,8 @@ class Client(object):
         The memcached "cache_memlimit" command.
 
         Args:
-            A number of megabytes to set as the new memlimit
+          memlimit: int, the number of megabytes to set as the new cache memory
+                    limit.
 
         Returns:
           If no exception is raised, always returns True.

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -724,6 +724,14 @@ class TestClient(ClientTestMixin, unittest.TestCase):
         ]
         assert result == {b'bob': b'[7 b; 0 s]'}
 
+    def test_cache_memlimit(self):
+        client = self.make_client([b'OK\r\n'])
+        result = client.cache_memlimit(8)
+        assert client.sock.send_bufs == [
+            b'cache_memlimit 8\r\n'
+        ]
+        assert result is True
+
     def test_python_dict_set_is_supported(self):
         client = self.make_client([b'STORED\r\n'])
         client[b'key'] = b'value'


### PR DESCRIPTION
This command allows clients to set a new cache memory limit. The
argument is a number expressed in megabytes.

Also, treat `OK` as an acceptable response string.

This is partially based on #172.