### PR TITLE
Parse version directly from pymemcache/__init__.py

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+New in version 2.1.1
+--------------------
+* Fix ``setup.py`` dependency on six already being installed.
+
 New in version 2.1.0
 --------------------
 * Public classes and exceptions can now be imported from the top-level

--- a/pymemcache/__init__.py
+++ b/pymemcache/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.1.0'
+__version__ = '2.1.1'
 
 from pymemcache.client.base import Client  # noqa
 from pymemcache.client.base import PooledClient  # noqa

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,3 @@
-[bumpversion]
-current_version = 2.0.0
-commit = False
-tag = True
-
 [bdist_wheel]
 universal = true
 
@@ -27,6 +22,3 @@ markers =
 show-source = True
 max-line-length = 80
 exclude = .tox/*,.venv/*,docs/*
-
-[bumpversion:file:pymemcache/__init__.py]
-

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,29 @@
 #!/usr/bin/env python
+
 import os
+import re
 
 from setuptools import setup, find_packages
-from pymemcache import __version__
 
 
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+def read(path):
+    return open(os.path.join(os.path.dirname(__file__), path)).read()
+
+
+def read_version(path):
+    match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", read(path), re.M)
+    if match:
+        return match.group(1)
+    raise RuntimeError("Unable to find __version__ in %s." % path)
 
 
 readme = read('README.rst')
 changelog = read('ChangeLog.rst')
+version = read_version('pymemcache/__init__.py')
 
 setup(
     name='pymemcache',
-    version=__version__,
+    version=version,
     author='Charles Gordon',
     author_email='charles@pinterest.com',
     packages=find_packages(),


### PR DESCRIPTION
We can no longer import the `__version__` attribute because there is no an
implicit runtime dependency on six (as of #197), and we can't guarantee
that six is installed until *after* `setup.py` is parsed and run.

Instead, parse the `__version__ = 'x.y.z'` string from `__init__.py` to
extract the version.

Fixes #214