### PR TITLE
Introduce package metadata configuration by using setup.cfg

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+New in version 2.2.0
+--------------------
+* Using ``setup.cfg`` metadata instead ``setup.py`` config to generate package.
+
 New in version 2.1.1
 --------------------
 * Fix ``setup.py`` dependency on six already being installed.

--- a/pymemcache/__init__.py
+++ b/pymemcache/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.1.1'
+__version__ = '2.2.0'
 
 from pymemcache.client.base import Client  # noqa
 from pymemcache.client.base import PooledClient  # noqa

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,32 @@
+[metadata]
+name = pymemcache
+version = attr: pymemcache.__version__
+author = Charles Gordon
+author_email = charles@pinterest.com
+description = "A comprehensive, fast, pure Python memcached client"
+long_description =
+    file: README.rst, ChangeLog.rst
+license = Apache License 2.0
+url = https://github.com/Pinterest/pymemcache
+keywords = memcache, client, database
+classifiers =
+    Programming Language :: Python
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: Implementation :: PyPy
+    License :: OSI Approved :: Apache Software License
+    Topic :: Database
+
+[options]
+setup_requires =
+    six
+install_requires =
+    six
+packages = find:
+
 [bdist_wheel]
 universal = true
 
@@ -7,16 +36,16 @@ omit = pymemcache/test/*
 [tool:pytest]
 norecursedirs = build docs/_build *.egg .tox *.venv
 addopts = 
-	--verbose
-	--tb=short
-	--capture=no
-	-rfEsxX
-	--cov=pymemcache --cov-config=setup.cfg --cov-report=xml --cov-report=term-missing
-	-m unit
+    --verbose
+    --tb=short
+    --capture=no
+    -rfEsxX
+    --cov=pymemcache --cov-config=setup.cfg --cov-report=xml --cov-report=term-missing
+    -m unit
 markers = 
-	unit
-	integration
-	benchmark
+    unit
+    integration
+    benchmark
 
 [flake8]
 show-source = True

--- a/setup.py
+++ b/setup.py
@@ -1,46 +1,5 @@
 #!/usr/bin/env python
 
-import os
-import re
+from setuptools import setup
 
-from setuptools import setup, find_packages
-
-
-def read(path):
-    return open(os.path.join(os.path.dirname(__file__), path)).read()
-
-
-def read_version(path):
-    match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", read(path), re.M)
-    if match:
-        return match.group(1)
-    raise RuntimeError("Unable to find __version__ in %s." % path)
-
-
-readme = read('README.rst')
-changelog = read('ChangeLog.rst')
-version = read_version('pymemcache/__init__.py')
-
-setup(
-    name='pymemcache',
-    version=version,
-    author='Charles Gordon',
-    author_email='charles@pinterest.com',
-    packages=find_packages(),
-    install_requires=['six'],
-    description='A comprehensive, fast, pure Python memcached client',
-    long_description=readme + '\n' + changelog,
-    license='Apache License 2.0',
-    url='https://github.com/Pinterest/pymemcache',
-    classifiers=[
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: Implementation :: PyPy',
-        'License :: OSI Approved :: Apache Software License',
-        'Topic :: Database',
-    ],
-)
+setup()


### PR DESCRIPTION
Since setuptools 30.3.0 we can use setup.cfg to configure package
for build and distribute. These changes propose to adopt a more
modern approach to package pymemcache by using latest and stable
feature of setuptools.

Overview:
- remove python code to maintain
- introduce package metadata,
- centralize version management in package metadata