### PR TITLE
Handle unicode key values in MockMemcacheClient correctly

### DIFF
--- a/pymemcache/test/test_utils.py
+++ b/pymemcache/test/test_utils.py
@@ -14,6 +14,15 @@ def test_get_set():
 
 
 @pytest.mark.unit()
+def test_get_set_unicide_key():
+    client = MockMemcacheClient()
+    assert client.get(u"hello") is None
+
+    client.set(b"hello", 12)
+    assert client.get(u"hello") == 12
+
+
+@pytest.mark.unit()
 def test_get_set_non_ascii_value():
     client = MockMemcacheClient()
     assert client.get(b"hello") is None

--- a/pymemcache/test/utils.py
+++ b/pymemcache/test/utils.py
@@ -44,8 +44,6 @@ class MockMemcacheClient(object):
 
     def get(self, key, default=None):
         if not self.allow_unicode_keys:
-            if isinstance(key, six.text_type):
-                raise MemcacheIllegalInputError(key)
             if isinstance(key, six.string_types):
                 try:
                     if isinstance(key, bytes):
@@ -79,8 +77,6 @@ class MockMemcacheClient(object):
 
     def set(self, key, value, expire=0, noreply=True):
         if not self.allow_unicode_keys:
-            if isinstance(key, six.text_type):
-                raise MemcacheIllegalInputError(key)
             if isinstance(key, six.string_types):
                 try:
                     if isinstance(key, bytes):
@@ -89,8 +85,6 @@ class MockMemcacheClient(object):
                         key = key.encode('ascii')
                 except (UnicodeEncodeError, UnicodeDecodeError):
                     raise MemcacheIllegalInputError
-        if isinstance(value, six.text_type):
-            raise MemcacheIllegalInputError(value)
         if (isinstance(value, six.string_types) and
                 not isinstance(value, six.binary_type)):
             try:


### PR DESCRIPTION
The actual client tries to encode unicode and if it fails
MemcacheIllegalInputError is raised. Fix the MockMemcacheClient to do
the same thing.

Fix bug #222