### PR TITLE
Allow to flush data on client reconnect.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,6 +126,7 @@ Credits
 * `Nicholas Charriere <https://github.com/nichochar>`_
 * `Joe Gordon <https://github.com/jogo>`_
 * `Jon Parise <https://github.com/jparise>`_
+* `Hervé Beraud <https://github.com/4383>`_
 
 We're Hiring!
 =============

--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -33,7 +33,8 @@ class HashClient(object):
         dead_timeout=60,
         use_pooling=False,
         ignore_exc=False,
-        allow_unicode_keys=False
+        allow_unicode_keys=False,
+        flush_on_reconnect=False
     ):
         """
         Constructor.
@@ -69,6 +70,8 @@ class HashClient(object):
         self._failed_clients = {}
         self._dead_clients = {}
         self._last_dead_check_time = time.time()
+        self.flush_on_reconnect = flush_on_reconnect
+        self.flush_on_next_connect = False
 
         self.hasher = hasher()
 
@@ -277,6 +280,9 @@ class HashClient(object):
             failed_metadata['attempts'] += 1
             failed_metadata['failed_time'] = time.time()
             self._failed_clients[server] = failed_metadata
+        # Handle if client user ask for flushing all data on reconnect
+        if self.flush_on_reconnect:
+            self.flush_on_next_connect = True
 
     def _run_cmd(self, cmd, key, default_val, *args, **kwargs):
         client = self._get_client(key)


### PR DESCRIPTION
Added "flush_on_reconnect" (defaults to off) to Client and HashClient
which will cause a client that has lost connection to a server and then
reconnects to flush the cache on the reconnect so that it doesn't get old
values from that server.