### PR TITLE
Add default_noreply paramter to HashClient

### DIFF
--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -33,7 +33,8 @@ class HashClient(object):
         dead_timeout=60,
         use_pooling=False,
         ignore_exc=False,
-        allow_unicode_keys=False
+        allow_unicode_keys=False,
+        default_noreply=True
     ):
         """
         Constructor.
@@ -81,6 +82,7 @@ class HashClient(object):
             'serializer': serializer,
             'deserializer': deserializer,
             'allow_unicode_keys': allow_unicode_keys,
+            'default_noreply': default_noreply,
         }
 
         if use_pooling is True:


### PR DESCRIPTION
This allows users to specify the noreply behavior upon creation of a HashClient like they are already able to do for Client and PooledClient.