### PR TITLE
Improve ASCII encoding failure exception

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -819,7 +819,8 @@ class Client(object):
                 try:
                     data = six.text_type(data).encode('ascii')
                 except UnicodeEncodeError as e:
-                    raise MemcacheIllegalInputError(str(e))
+                    raise MemcacheIllegalInputError(
+                            "Data values must be binary-safe: %s" % e)
 
             cmds.append(name + b' ' + key + b' ' +
                         six.text_type(flags).encode('ascii') +


### PR DESCRIPTION
Memcache can only store binary-safe values. We raise an exception when
we're unable to encode a data value using the 'ascii' codec. Improve the
exception message to make the error case clearer.

See #227