### PR TITLE
Drop official support for Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ matrix:
   include:
     - python: 2.7
       env: TOXENV=py27,py27-flake8
-    - python: 3.4
-      env: TOXENV=py34
     - python: 3.5
       env: TOXENV=py35
     - python: 3.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,6 @@ keywords = memcache, client, database
 classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7


### PR DESCRIPTION
Python 3.4 has reached end-of-life so remove it from the set of
officially supported Python versions.