### PR TITLE
Add check that `expire` is an integer

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -113,7 +113,8 @@ def _check_integer(value, name, encoding):
     """Check that a value is an integer and encode it as a binary string"""
     if isinstance(value, six.integer_types):  # includes "long" on py2
         return six.text_type(value).encode(encoding)
-    elif isinstance(value, six.text_type):
+    # TODO: drop this behavior in a future version of pymemcached
+    elif isinstance(value, VALID_STRING_TYPES):
         try:
             int(value)
             return six.text_type(value).encode(encoding)

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -763,6 +763,18 @@ class TestClient(ClientTestMixin, unittest.TestCase):
         with pytest.raises(MemcacheIllegalInputError):
             _set()
 
+    def test_set_key_with_noninteger_expire(self):
+        client = self.make_client([b''])
+
+        for noreply in (True, False):
+            for expire in (1.5, "1.5", "not_an_int"):
+                def _set():
+                    client.set(b'finekey', b'finevalue',
+                               noreply=noreply, expire=expire)
+
+                with pytest.raises(MemcacheIllegalInputError):
+                    _set()
+
     def test_set_many_socket_handling(self):
         client = self.make_client([b'STORED\r\n'])
         result = client.set_many({b'key': b'value'}, noreply=False)


### PR DESCRIPTION
Part of #239

If a caller tries to send a fractional expiration time, that should be caught and rejected with a MemcacheIllegalInputError. Otherwise, calls with `noreply=True` could fail to parse, but the client won't pick up on this until the next call to memcache which reads the reply.

The case we're seeking to avoid is this:

```python
from pymemcache.client.base import Client
client = Client(("localhost", 11211))
client.set("foo", "bar", expire=1.5, noreply=True)
client.get("foo")  # triggers MemcacheUnknownCommandError
```

In addition to allowing for values which are `int` (or `long` on py2), this implementation allows for `expire` values to be a text type (str on py2, bytes or str on py3), so long as `int(expire)` correctly converts it. If `int(expire)` fails (ValueError), that indicates that the input could not be treated as an int and is a failure.

Applies `Client._store_cmd`, which covers a class of commands, and `Client.touch`, which appears to be the only command with a non-shared implementation that includes `expire` as a parameter.

---

I tried to write the test using `pytest.mark.parametrize`, but something about the way the testsuite is structured makes that not work (or at least, not work in the way that I'm used to). I'm happy to rewrite the test in a form which is more fitting with the idioms of the current testsuite, but I'd need some direction on that.