### PR TITLE
Add noreply warning to getting_started doc

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -128,7 +128,7 @@ Best Practices
    your process when memcached is slow. You might also want to enable the
    ``no_delay`` option, which sets the TCP_NODELAY flag on the connection's
    socket.
- - Use the ``noreply`` flag for a significant performance boost. The ``"noreply``
+ - Use the ``noreply`` flag for a significant performance boost. The ``noreply``
    flag is enabled by default for "set", "add", "replace", "append", "prepend",
    and "delete". It is disabled by default for "cas", "incr" and "decr". It
    obviously doesn't apply to any get calls.
@@ -140,3 +140,15 @@ Best Practices
    errors, from killing your web requests. Do not use this flag if you need to
    know about errors from memcache, and make sure you have some other way to
    detect memcache server failures.
+
+.. WARNING::
+
+    ``noreply`` will not read errors returned from the memcached server.
+
+    If a function with ``noreply=True`` causes an error on the server, it will
+    still succeed and your next call which reads a response from memcached may
+    fail unexpectedly.
+
+    ``pymemcached`` will try to catch and stop you from sending malformed
+    inputs to memcached, but if you are having unexplained errors, setting
+    ``noreply=False`` may help you troubleshoot the issue.


### PR DESCRIPTION
resolves #239

Add a warning to the Best Practices section of the Getting Started doc which explains the interaction between `noreply=True` and error handling.

Also, fix a very minor typo, ``"noreply`` in a nearby line.

I understand that "WARNING" boxes are very shouty and attention-grabby, and many people are shy about using them. However, (1) in the readthedocs theme, they're orange, not red, and less harsh, and (2) this seems genuinely warning-worthy to me.

I thought for a moment about how to fit this into the client documentation, but it doesn't fit well anywhere in there, IMO.

For ease of review, here's what it looks like when rendered:
<img src="https://user-images.githubusercontent.com/1300022/61809295-013a9300-ae0b-11e9-9047-b19308e7e296.png" width="80%" />