### PR TITLE
Be more consistent about using Client.encoding

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -594,7 +594,7 @@ class Client(object):
           value of the key, or None if the key wasn't found.
         """
         key = self.check_key(key)
-        cmd = b'incr ' + key + b' ' + six.text_type(value).encode('ascii')
+        cmd = b'incr ' + key + b' ' + six.text_type(value).encode(self.encoding)
         if noreply:
             cmd += b' noreply'
         cmd += b'\r\n'
@@ -619,7 +619,7 @@ class Client(object):
           value of the key, or None if the key wasn't found.
         """
         key = self.check_key(key)
-        cmd = b'decr ' + key + b' ' + six.text_type(value).encode('ascii')
+        cmd = b'decr ' + key + b' ' + six.text_type(value).encode(self.encoding)
         if noreply:
             cmd += b' noreply'
         cmd += b'\r\n'
@@ -648,7 +648,9 @@ class Client(object):
         if noreply is None:
             noreply = self.default_noreply
         key = self.check_key(key)
-        cmd = b'touch ' + key + b' ' + six.text_type(expire).encode('ascii')
+        cmd = (
+            b'touch ' + key + b' ' + six.text_type(expire).encode(self.encoding)
+        )
         if noreply:
             cmd += b' noreply'
         cmd += b'\r\n'
@@ -729,7 +731,7 @@ class Client(object):
         """
         if noreply is None:
             noreply = self.default_noreply
-        cmd = b'flush_all ' + six.text_type(delay).encode('ascii')
+        cmd = b'flush_all ' + six.text_type(delay).encode(self.encoding)
         if noreply:
             cmd += b' noreply'
         cmd += b'\r\n'


### PR DESCRIPTION
This is a stylistic issue with little chance for actual impact. Some methods use 'ascii' verbatim and some use `self.encoding` (which defaults to 'ascii'). Those which are using `ascii` are only supposed to be accepting integer inputs, so this is actually fine.

However, the result is a potentially confusing discrepancy -- why does `Client.touch` use `ascii` while `Client.add` uses `self.encoding`? To alleviate this potential confusion, be consistent about applying `self.encoding` to all memcached commands in the base client.

This does not impact the `_check_key` func, which re-encodes potential unicode inputs as ASCII.

Bonus: this also means that if I want to be exceptionally clever (read: stupid), I could register a custom codec which does something weird and then use that in here.