### PR TITLE
Check integer input values to Client methods

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+New in version 3.0.0 (unreleased)
+---------------------------------
+
+* Validate integer inputs for ``expire``, ``delay``, ``incr``, ``decr``, and
+  ``memlimit`` -- non-integer values now cause ``MemcacheIllegalInputError``s
+
 New in version 2.2.0
 --------------------
 * Drop official support for Python 3.4.

--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -594,7 +594,8 @@ class Client(object):
           value of the key, or None if the key wasn't found.
         """
         key = self.check_key(key)
-        cmd = b'incr ' + key + b' ' + six.text_type(value).encode(self.encoding)
+        value = self._check_integer(value, "value")
+        cmd = b'incr ' + key + b' ' + value
         if noreply:
             cmd += b' noreply'
         cmd += b'\r\n'
@@ -619,7 +620,8 @@ class Client(object):
           value of the key, or None if the key wasn't found.
         """
         key = self.check_key(key)
-        cmd = b'decr ' + key + b' ' + six.text_type(value).encode(self.encoding)
+        value = self._check_integer(value, "value")
+        cmd = b'decr ' + key + b' ' + value
         if noreply:
             cmd += b' noreply'
         cmd += b'\r\n'
@@ -648,9 +650,8 @@ class Client(object):
         if noreply is None:
             noreply = self.default_noreply
         key = self.check_key(key)
-        cmd = (
-            b'touch ' + key + b' ' + six.text_type(expire).encode(self.encoding)
-        )
+        expire = self._check_integer(expire, "expire")
+        cmd = b'touch ' + key + b' ' + expire
         if noreply:
             cmd += b' noreply'
         cmd += b'\r\n'
@@ -696,8 +697,8 @@ class Client(object):
         Returns:
           If no exception is raised, always returns True.
         """
-
-        self._fetch_cmd(b'cache_memlimit', [str(int(memlimit))], False)
+        memlimit = self._check_integer(memlimit, "memlimit")
+        self._fetch_cmd(b'cache_memlimit', [memlimit], False)
         return True
 
     def version(self):
@@ -731,7 +732,8 @@ class Client(object):
         """
         if noreply is None:
             noreply = self.default_noreply
-        cmd = b'flush_all ' + six.text_type(delay).encode(self.encoding)
+        delay = self._check_integer(delay, "delay")
+        cmd = b'flush_all ' + delay
         if noreply:
             cmd += b' noreply'
         cmd += b'\r\n'
@@ -763,6 +765,15 @@ class Client(object):
         if line.startswith(b'SERVER_ERROR'):
             error = line[line.find(b' ') + 1:]
             raise MemcacheServerError(error)
+
+    def _check_integer(self, value, name):
+        """Check that a value is an integer and encode it as a binary string"""
+        if not isinstance(value, six.integer_types):  # includes "long" on py2
+            raise MemcacheIllegalInputError(
+                '%s must be integer, got bad value: %r' % (name, value)
+            )
+
+        return six.text_type(value).encode(self.encoding)
 
     def _extract_value(self, expect_cas, line, buf, remapped_keys,
                        prefixed_keys):
@@ -838,7 +849,7 @@ class Client(object):
             extra += b' ' + cas
         if noreply:
             extra += b' noreply'
-        expire = six.text_type(expire).encode(self.encoding)
+        expire = self._check_integer(expire, "expire")
 
         for key, data in six.iteritems(values):
             # must be able to reliably map responses back to the original order

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -763,6 +763,23 @@ class TestClient(ClientTestMixin, unittest.TestCase):
         with pytest.raises(MemcacheIllegalInputError):
             _set()
 
+    def test_set_key_with_noninteger_expire(self):
+        client = self.make_client([b''])
+
+        class _OneLike(object):
+            """object that looks similar to the int 1"""
+            def __str__(self):
+                return "1"
+
+        for noreply in (True, False):
+            for expire in (1.5, _OneLike(), "1"):
+                def _set():
+                    client.set(b'finekey', b'finevalue',
+                               noreply=noreply, expire=expire)
+
+                with pytest.raises(MemcacheIllegalInputError):
+                    _set()
+
     def test_set_many_socket_handling(self):
         client = self.make_client([b'STORED\r\n'])
         result = client.set_many({b'key': b'value'}, noreply=False)


### PR DESCRIPTION
After the conversation on #240 , I'm starting to change my mind on whether or not it's even worthwhile to continue to support callers using `expire="1"` and the like. That usage is not documented, and supporting it doesn't really make things that much better for callers.

If a caller tries to send
- a fractional expiration time
- a string for the "incr" command
- delay=None (instead of delay=0)

The pymemcache base client will now catch these usage mistakes and throw a MemcacheIllegalInputError.

Although there are existing valid (but undocumented) usages of the current string conversion behavior, the docs state that these values are supposed to be ints. Now if a non-int value is used, it will immediately trigger an error.

This behavior is superior to the prior behavior especially in the case where a command is used with `noreply=True`, as described in #240 (the commit message here has it too). 

Applies to all commands using `expire`, `delay`, incr and decr inputs, and memlimit.

Add a note to the changelog which puts positive spin on this: pymemcache is now validating inputs which it didn't used to validate.

closes #240