### PR TITLE
Fix flags when setting multiple values at once

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+New in version 2.2.1
+--------------------
+* Fix ``flags`` when setting multiple differently-typed values at once.
+
 New in version 2.2.0
 --------------------
 * Drop official support for Python 3.4.

--- a/pymemcache/__init__.py
+++ b/pymemcache/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.2.0'
+__version__ = '2.2.1'
 
 from pymemcache.client.base import Client  # noqa
 from pymemcache.client.base import PooledClient  # noqa

--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -854,15 +854,14 @@ class Client(object):
 
             key = self.check_key(key)
             if self.serializer:
-                data, serializer_flags = self.serializer(key, data)
-                # Use the serializer's flags if the caller hasn't specified an
-                # explicit, overridding value.
-                if flags is None:
-                    flags = serializer_flags
+                data, data_flags = self.serializer(key, data)
+            else:
+                data_flags = 0
 
-            # Set flags to 0 if none were provided by the caller or serializer.
-            if flags is None:
-                flags = 0
+            # If 'flags' was explicitly provided, it overrides the value
+            # returned by the serializer.
+            if flags is not None:
+                data_flags = flags
 
             if not isinstance(data, six.binary_type):
                 try:
@@ -872,7 +871,7 @@ class Client(object):
                             "Data values must be binary-safe: %s" % e)
 
             cmds.append(name + b' ' + key + b' ' +
-                        six.text_type(flags).encode(self.encoding) +
+                        six.text_type(data_flags).encode(self.encoding) +
                         b' ' + expire +
                         b' ' + six.text_type(len(data)).encode(self.encoding) +
                         extra + b'\r\n' + data + b'\r\n')


### PR DESCRIPTION
We introduced the ability to override the serializer-returned flags
values in 26f7c1b1. Unfortunately, there was a flaw in that logic which
resulted in the first item's flags being used for all later items. This
bug primarily affected set_many()'s behavior when the data dictionary
contained multiple different value types which were assigned different
per-value flags values by the serializer.

For example:

    set_many({'a': 'string', 'b': 10})

If a serializer returned different flags for strings (e.g. 1) and
integer values (e.g. 2), the previous logic would have set ``flags``
to 1 the first time through the loop and repeated that value for the
second item, instead of using 2.

This was the intended behavior when ``flags`` was explicitly passed to
set_many(), but not for the default case where we still want to respect
the flags values returned by the serializer.