### PR TITLE
Validate cas inputs as strings of digits

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -13,6 +13,9 @@ New in version 3.0.0 (unreleased)
   as methods. (`serialize` and `deserialize` are still supported but considered
   deprecated)
 
+* Validate inputs for ``cas`` -- values which are not integers or strings of
+  0-9 now raise ``MemcacheIllegalInputError``
+
 New in version 2.2.2
 --------------------
 * Fix ``long_description`` string in Python packaging.

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -471,34 +471,47 @@ class TestClient(ClientTestMixin, unittest.TestCase):
         result = client.prepend(b'key', b'value', noreply=False)
         assert result is True
 
+    def test_cas_malformed(self):
+        client = self.make_client([b'STORED\r\n'])
+        with pytest.raises(MemcacheIllegalInputError):
+            client.cas(b'key', b'value', 'nonintegerstring', noreply=False)
+
+        with pytest.raises(MemcacheIllegalInputError):
+            # even a space makes it a noninteger string
+            client.cas(b'key', b'value', '123 ', noreply=False)
+
+        with pytest.raises(MemcacheIllegalInputError):
+            # non-ASCII digit
+            client.cas(b'key', b'value', u'⁰', noreply=False)
+
     def test_cas_stored(self):
         client = self.make_client([b'STORED\r\n'])
-        result = client.cas(b'key', b'value', b'cas', noreply=False)
+        result = client.cas(b'key', b'value', b'123', noreply=False)
         assert result is True
 
         # unit test for encoding passed in __init__()
         client = self.make_client([b'STORED\r\n'], encoding='utf-8')
-        result = client.cas(b'key', b'value', b'cas', noreply=False)
+        result = client.cas(b'key', b'value', b'123', noreply=False)
         assert result is True
 
     def test_cas_exists(self):
         client = self.make_client([b'EXISTS\r\n'])
-        result = client.cas(b'key', b'value', b'cas', noreply=False)
+        result = client.cas(b'key', b'value', b'123', noreply=False)
         assert result is False
 
         # unit test for encoding passed in __init__()
         client = self.make_client([b'EXISTS\r\n'], encoding='utf-8')
-        result = client.cas(b'key', b'value', b'cas', noreply=False)
+        result = client.cas(b'key', b'value', b'123', noreply=False)
         assert result is False
 
     def test_cas_not_found(self):
         client = self.make_client([b'NOT_FOUND\r\n'])
-        result = client.cas(b'key', b'value', b'cas', noreply=False)
+        result = client.cas(b'key', b'value', b'123', noreply=False)
         assert result is None
 
         # unit test for encoding passed in __init__()
         client = self.make_client([b'NOT_FOUND\r\n'], encoding='utf-8')
-        result = client.cas(b'key', b'value', b'cas', noreply=False)
+        result = client.cas(b'key', b'value', b'123', noreply=False)
         assert result is None
 
     def test_cr_nl_boundaries(self):

--- a/pymemcache/test/test_integration.py
+++ b/pymemcache/test/test_integration.py
@@ -151,7 +151,12 @@ def test_cas(client_class, host, port, socket_module):
     result = client.set(b'key', b'value', noreply=False)
     assert result is True
 
+    # binary, string, and raw int all match -- should all be encoded as b'1'
     result = client.cas(b'key', b'value', b'1', noreply=False)
+    assert result is False
+    result = client.cas(b'key', b'value', '1', noreply=False)
+    assert result is False
+    result = client.cas(b'key', b'value', 1, noreply=False)
     assert result is False
 
     result, cas = client.gets(b'key')


### PR DESCRIPTION
For consideration for v3.0.0

I was looking at other potential values to validate, and trying to make head-or-tail of #233 (which ultimately has to be some kind of user-error, but it's pretty hard to tell what without better information).
I'm not dead-set on making this change, but wanted to put it in a PR for comment.

'cas' is documented as needing to be an int or bytestring of the digits 0-9. However, this is not actually enforced and it is possible to pass a value to pymemcache which doesn't conform to these rules. In fact, you can do weird things like `cas=b' noreply'` and potentially trigger "unexpected" behavior.

To go along with validating int inputs, validate cas inputs. However, these are not necessarily integers. Instead, if an int or string is given, it will be encoded as a bytestring. But in order to validate the value given, it is regex checked against an expression for `^[0-9]*$`
(NB: You could also use `int(cas)` for very similar checking.)

Unlike the integer inputs, `cas` has legitimate non-integer values like `b'0001'` which ought to be preserved.