### PR TITLE
Fixed issue where add() function returns True when key already exists even when noreply is not set True

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -376,7 +376,7 @@ class Client(object):
           return value is True if the value was stored, and False if it was
           not (because the key already existed).
         """
-        if noreply is None:
+        if noreply is True:
             noreply = self.default_noreply
         return self._store_cmd(b'add', {key: value}, expire, noreply,
                                flags=flags)[key]


### PR DESCRIPTION
This addresses the variation between the expected behaviour of the add() function in the documentation and its actual behaviour as described in https://github.com/pinterest/pymemcache/issues/253.

The add() function _should_ return True if a key is added successfully or False if a key cannot be added as the same key already exists in Memcached. This is, unless, the user sets noreply=True, where the function will always return True.

However, the actual behaviour is that it will always return True _unless the user explicitly sets noreply=False_, which is not how the documentation implies it works.