### PR TITLE
trivial: update library name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,10 +65,10 @@ so using it with libraries like gevent is out of the question, and its
 dependency on libmemcached poses challenges (e.g., it must be built against
 the same version of libmemcached that it will use at runtime).
 
-Python-memcache
----------------
+python-memcached
+----------------
 
-The python-memcache library implements the entire memcached text protocol, has
+The python-memcached library implements the entire memcached text protocol, has
 a single timeout for all socket calls and has a flexible approach to
 serialization and deserialization. It is also written entirely in Python, so
 it works well with libraries like gevent. However, it is tied to using thread


### PR DESCRIPTION
I was reading through the documentation and noticed a minor
inconsistency in the naming of the python-memcached library. This
commit updates the library name to reflect the real library we're
referencing.