### PR TITLE
Add prepend and append support to MockMemcacheClient

### DIFF
--- a/pymemcache/test/test_utils.py
+++ b/pymemcache/test/test_utils.py
@@ -103,3 +103,13 @@ def test_incr_decr():
 
     client.decr(b"k", 2)
     assert client.get(b"k") == 4
+
+
+@pytest.mark.unit()
+def test_prepand_append():
+    client = MockMemcacheClient()
+
+    client.set(b"k", '1')
+    client.append(b"k", 'a')
+    client.prepend(b"k", 'p')
+    assert client.get(b"k") == b'p1a'

--- a/pymemcache/test/utils.py
+++ b/pymemcache/test/utils.py
@@ -138,6 +138,30 @@ class MockMemcacheClient(object):
             self.delete(key, noreply)
         return True
 
+    def prepend(self, key, value, expire=0, noreply=None, flags=None):
+        current = self.get(key)
+        if current is not None:
+            if (isinstance(value, six.string_types) and
+                    not isinstance(value, six.binary_type)):
+                try:
+                    value = value.encode(self.encoding)
+                except (UnicodeEncodeError, UnicodeDecodeError):
+                    raise MemcacheIllegalInputError
+            self.set(key, value + current)
+        return True
+
+    def append(self, key, value, expire=0, noreply=None, flags=None):
+        current = self.get(key)
+        if current is not None:
+            if (isinstance(value, six.string_types) and
+                    not isinstance(value, six.binary_type)):
+                try:
+                    value = value.encode(self.encoding)
+                except (UnicodeEncodeError, UnicodeDecodeError):
+                    raise MemcacheIllegalInputError
+            self.set(key, current + value)
+        return True
+
     delete_multi = delete_many
 
     def stats(self):


### PR DESCRIPTION
So that MockMemcacheClient is more complete and can be used for testing
prepend and append cases.