### PR TITLE
Add touch method to HashClient

### DIFF
--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -425,7 +425,6 @@ class HashClient(object):
     def touch(self, key, *args, **kwargs):
         return self._run_cmd('touch', key, False, *args, **kwargs)
 
-
     def flush_all(self):
         for _, client in self.clients.items():
             self._safely_run_func(client, client.flush_all, False)

--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -422,6 +422,10 @@ class HashClient(object):
     def replace(self, key, *args, **kwargs):
         return self._run_cmd('replace', key, False, *args, **kwargs)
 
+    def touch(self, key, *args, **kwargs):
+        return self._run_cmd('touch', key, False, *args, **kwargs)
+
+
     def flush_all(self):
         for _, client in self.clients.items():
             self._safely_run_func(client, client.flush_all, False)

--- a/pymemcache/test/test_client_hash.py
+++ b/pymemcache/test/test_client_hash.py
@@ -143,6 +143,21 @@ class TestHashClient(ClientTestMixin, unittest.TestCase):
         assert (result ==
                 {b'key1': (b'value1', b'1'), b'key3': (b'value2', b'1')})
 
+    def test_touch_not_found(self):
+        client = self.make_client([b'NOT_FOUND\r\n'])
+        result = client.touch(b'key', noreply=False)
+        assert result is False
+
+    def test_touch_no_expiry_found(self):
+        client = self.make_client([b'TOUCHED\r\n'])
+        result = client.touch(b'key', noreply=False)
+        assert result is True
+
+    def test_touch_with_expiry_found(self):
+        client = self.make_client([b'TOUCHED\r\n'])
+        result = client.touch(b'key', 1, noreply=False)
+        assert result is True
+
     def test_no_servers_left(self):
         from pymemcache.client.hash import HashClient
         client = HashClient(

--- a/pymemcache/test/test_integration.py
+++ b/pymemcache/test/test_integration.py
@@ -230,6 +230,23 @@ def test_incr_decr(client_class, host, port, socket_module):
 
 
 @pytest.mark.integration()
+def test_touch(client_class, host, port, socket_module):
+    client = client_class((host, port), socket_module=socket_module)
+    client.flush_all()
+
+    result = client.touch(b'key', noreply=False)
+    assert result is False
+
+    result = client.set(b'key', b'0', 1, noreply=False)
+    assert result is True
+
+    result = client.touch(b'key', noreply=False)
+    assert result is True
+
+    result = client.touch(b'key', 1, noreply=False)
+    assert result is True
+
+@pytest.mark.integration()
 def test_misc(client_class, host, port, socket_module):
     client = Client((host, port), socket_module=socket_module)
     client.flush_all()

--- a/pymemcache/test/test_integration.py
+++ b/pymemcache/test/test_integration.py
@@ -246,6 +246,7 @@ def test_touch(client_class, host, port, socket_module):
     result = client.touch(b'key', 1, noreply=False)
     assert result is True
 
+
 @pytest.mark.integration()
 def test_misc(client_class, host, port, socket_module):
     client = Client((host, port), socket_module=socket_module)


### PR DESCRIPTION
Adds the `touch` method to `pymemcache.client.hash.HashClient`. This method already exists in `pymemcache.client.base.Client` & `pymemcaache.client.base.PooledClient`

