### PR TITLE
Adding clear method to MockMemcacheClient

### DIFF
--- a/pymemcache/test/utils.py
+++ b/pymemcache/test/utils.py
@@ -43,6 +43,10 @@ class MockMemcacheClient(object):
         self.ignore_exc = ignore_exc
         self.encoding = encoding
 
+    def clear(self):
+        """Method used to clear/reset mock cache"""
+        self._contents.clear()
+
     def get(self, key, default=None):
         if not self.allow_unicode_keys:
             if isinstance(key, six.string_types):


### PR DESCRIPTION
Adding a `clear` method to `MockMemcacheClient` as a way to reset/clear the mock cache.