### PR TITLE
Enforcing consistency between the client mock and real client so they reflect the same behavior

### DIFF
--- a/pymemcache/test/utils.py
+++ b/pymemcache/test/utils.py
@@ -22,6 +22,8 @@ class MockMemcacheClient(object):
     def __init__(self,
                  server=None,
                  serde=None,
+                 serializer=None,
+                 deserializer=None,
                  connect_timeout=None,
                  timeout=None,
                  no_delay=False,
@@ -32,7 +34,7 @@ class MockMemcacheClient(object):
 
         self._contents = {}
 
-        self.serde = serde or LegacyWrappingSerde(None, None)
+        self.serde = serde or LegacyWrappingSerde(serializer, deserializer)
         self.allow_unicode_keys = allow_unicode_keys
 
         # Unused, but present for interface compatibility


### PR DESCRIPTION
Refactoring the client mock to better mimic the actual behavior of the real client. In this particular case deserialize and serialize are deprecated but still supported in Pymemcahce version 3.0.0. The Mock should also depreciate these items rather than completely removing these kwargs in order to keep consistency between the client mock and real mock.
