### PR TITLE
Update MockMemcacheClient to reuse check_key

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -82,7 +82,7 @@ STAT_TYPES = {
 # Common helper functions.
 
 
-def _check_key(key, allow_unicode_keys, key_prefix=b''):
+def check_key_helper(key, allow_unicode_keys, key_prefix=b''):
     """Checks key and add key_prefix."""
     if allow_unicode_keys:
         if isinstance(key, six.text_type):
@@ -272,8 +272,8 @@ class Client(object):
 
     def check_key(self, key):
         """Checks key and add key_prefix."""
-        return _check_key(key, allow_unicode_keys=self.allow_unicode_keys,
-                          key_prefix=self.key_prefix)
+        return check_key_helper(key, allow_unicode_keys=self.allow_unicode_keys,
+                                key_prefix=self.key_prefix)
 
     def _connect(self):
         self.close()
@@ -1040,8 +1040,8 @@ class PooledClient(object):
 
     def check_key(self, key):
         """Checks key and add key_prefix."""
-        return _check_key(key, allow_unicode_keys=self.allow_unicode_keys,
-                          key_prefix=self.key_prefix)
+        return check_key_helper(key, allow_unicode_keys=self.allow_unicode_keys,
+                                key_prefix=self.key_prefix)
 
     def _create_client(self):
         client = Client(self.server,

--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -3,7 +3,7 @@ import time
 import logging
 import six
 
-from pymemcache.client.base import Client, PooledClient, _check_key
+from pymemcache.client.base import Client, PooledClient, check_key_helper
 from pymemcache.client.rendezvous import RendezvousHash
 from pymemcache.exceptions import MemcacheError
 
@@ -122,7 +122,7 @@ class HashClient(object):
         self.hasher.remove_node(key)
 
     def _get_client(self, key):
-        _check_key(key, self.allow_unicode_keys, self.key_prefix)
+        check_key_helper(key, self.allow_unicode_keys, self.key_prefix)
         if len(self._dead_clients) > 0:
             current_time = time.time()
             ldc = self._last_dead_check_time

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -296,6 +296,14 @@ class ClientTestMixin(object):
         result = client.get(b'key')
         assert result is None
 
+    def test_space_key(self):
+        client = self.make_client([b''])
+        with pytest.raises(MemcacheIllegalInputError):
+            client.get(b'space key')
+
+        with pytest.raises(MemcacheIllegalInputError):
+            client.set(b'space key', b'value')
+
     def test_get_not_found_default(self):
         client = self.make_client([b'END\r\n'])
         result = client.get(b'key', default='foobar')


### PR DESCRIPTION
Our current MockMemcacheClient doesn't throw an error if a key has a
space, and given MockMemcacheClient can be consumed by downstream
things, we want it to act as close to the real client as possible.

Rename _check_key to check_key_helper so we aren't importing a private
function.