### PR TITLE
Fix corner case with dead server coming back alive

### DIFF
--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -141,7 +141,7 @@ class HashClient(object):
 
     def _get_client(self, key):
         check_key_helper(key, self.allow_unicode_keys, self.key_prefix)
-        if len(self._dead_clients) > 0:
+        if self._dead_clients:
             self._retry_dead()
 
         server = self.hasher.get_node(key)

--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -127,14 +127,18 @@ class HashClient(object):
         # we have dead clients and we have reached the
         # timeout retry
         if current_time - ldc > self.dead_timeout:
+            candidates = []
             for server, dead_time in self._dead_clients.items():
                 if current_time - dead_time > self.dead_timeout:
-                    logger.debug(
-                        'bringing server back into rotation %s',
-                        server
-                    )
-                    self.add_server(*server)
-                    self._last_dead_check_time = current_time
+                    candidates.append(server)
+            for server in candidates:
+                logger.debug(
+                    'bringing server back into rotation %s',
+                    server
+                )
+                self.add_server(*server)
+                del self._dead_clients[server]
+            self._last_dead_check_time = current_time
 
     def _get_client(self, key):
         check_key_helper(key, self.allow_unicode_keys, self.key_prefix)

--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -124,8 +124,7 @@ class HashClient(object):
     def _retry_dead(self):
         current_time = time.time()
         ldc = self._last_dead_check_time
-        # we have dead clients and we have reached the
-        # timeout retry
+        # We have reached the retry timeout
         if current_time - ldc > self.dead_timeout:
             candidates = []
             for server, dead_time in self._dead_clients.items():


### PR DESCRIPTION
Hey, 

I haven't opened an issue for that as I believe it's easier to show failing tests.

Looks like `clients/hash` behaves incorrectly when dead server comes back alive - it's never removed from `dead_clients` and thus retried indefinitely. 

Failing test and fix are visible in 35ee9de, rest of PR simply adds some test coverage and refactors existing code a little.