### PR TITLE
Align Client and MockMemcacheClient to ease third-party testing #279

### DIFF
--- a/pymemcache/__init__.py
+++ b/pymemcache/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.1.1'
+__version__ = '3.1.0'
 
 from pymemcache.client.base import Client  # noqa
 from pymemcache.client.base import PooledClient  # noqa

--- a/pymemcache/__init__.py
+++ b/pymemcache/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.1.0'
+__version__ = '3.1.1'
 
 from pymemcache.client.base import Client  # noqa
 from pymemcache.client.base import PooledClient  # noqa

--- a/pymemcache/test/utils.py
+++ b/pymemcache/test/utils.py
@@ -8,8 +8,9 @@ This module is considered public API.
 import time
 
 import six
+import socket
 
-from pymemcache.exceptions import MemcacheIllegalInputError
+from pymemcache.exceptions import MemcacheIllegalInputError, MemcacheClientError
 from pymemcache.serde import LegacyWrappingSerde
 from pymemcache.client.base import check_key_helper
 
@@ -29,9 +30,11 @@ class MockMemcacheClient(object):
                  timeout=None,
                  no_delay=False,
                  ignore_exc=False,
+                 socket_module=None,
                  default_noreply=True,
                  allow_unicode_keys=False,
-                 encoding='ascii'):
+                 encoding='ascii',
+                 tls_context=None):
 
         self._contents = {}
 
@@ -44,15 +47,85 @@ class MockMemcacheClient(object):
         self.timeout = timeout
         self.no_delay = no_delay
         self.ignore_exc = ignore_exc
+        self.socket_module = socket
+        self.sock = None
         self.encoding = encoding
+        self.tls_context = tls_context
 
     def check_key(self, key):
         """Checks key and add key_prefix."""
         return check_key_helper(key, allow_unicode_keys=self.allow_unicode_keys)
 
-    def clear(self):
-        """Method used to clear/reset mock cache"""
-        self._contents.clear()
+    def close(self):
+        pass
+
+    def set(self, key, value, expire=0, noreply=True, flags=None):
+        key = self.check_key(key)
+        if (isinstance(value, six.string_types) and
+                not isinstance(value, six.binary_type)):
+            try:
+                value = value.encode(self.encoding)
+            except (UnicodeEncodeError, UnicodeDecodeError):
+                raise MemcacheIllegalInputError
+
+        value, flags = self.serde.serialize(key, value)
+
+        if expire:
+            expire += time.time()
+
+        self._contents[key] = expire, value, flags
+        return True
+
+    def set_many(self, values, expire=0, noreply=True, flags=None):
+        result = []
+        for key, value in six.iteritems(values):
+            ret = self.set(key, value, expire, noreply, flags=flags)
+            if not ret:
+                result.append(key)
+        return [] if noreply else result
+
+    set_multi = set_many
+
+    def add(self, key, value, expire=0, noreply=True, flags=None):
+        current = self.get(key)
+        present = current is not None
+        if not present:
+            self.set(key, value, expire, noreply, flags=flags)
+        return noreply or not present
+
+    def replace(self, key, value, expire=0, noreply=True, flags=None):
+        current = self.get(key)
+        present = current is not None
+        if present:
+            self.set(key, value, expire, noreply, flags=flags)
+        return noreply or present
+
+    def append(self, key, value, expire=0, noreply=True, flags=None):
+        current = self.get(key)
+        if current is not None:
+            if (isinstance(value, six.string_types) and
+                    not isinstance(value, six.binary_type)):
+                try:
+                    value = value.encode(self.encoding)
+                except (UnicodeEncodeError, UnicodeDecodeError):
+                    raise MemcacheIllegalInputError
+            self.set(key, current + value, expire, noreply, flags=flags)
+        return True
+
+    def prepend(self, key, value, expire=0, noreply=True, flags=None):
+        current = self.get(key)
+        if current is not None:
+            if (isinstance(value, six.string_types) and
+                    not isinstance(value, six.binary_type)):
+                try:
+                    value = value.encode(self.encoding)
+                except (UnicodeEncodeError, UnicodeDecodeError):
+                    raise MemcacheIllegalInputError
+            self.set(key, value + current, expire, noreply, flags=flags)
+        return True
+
+    def cas(self, key, value, cas, expire=0, noreply=False, flags=None):
+        raise MemcacheClientError('CAS is not enabled for this instance')
 
     def get(self, key, default=None):
         key = self.check_key(key)
@@ -77,29 +150,18 @@ class MockMemcacheClient(object):
 
     get_multi = get_many
 
-    def set(self, key, value, expire=0, noreply=True, flags=0):
+    def delete(self, key, noreply=True):
         key = self.check_key(key)
-        if (isinstance(value, six.string_types) and
-                not isinstance(value, six.binary_type)):
-            try:
-                value = value.encode(self.encoding)
-            except (UnicodeEncodeError, UnicodeDecodeError):
-                raise MemcacheIllegalInputError
+        current = self._contents.pop(key, None)
+        present = current is not None
+        return noreply or present
 
-        value, flags = self.serde.serialize(key, value)
-
-        if expire:
-            expire += time.time()
-
-        self._contents[key] = expire, value, flags
+    def delete_many(self, keys, noreply=True):
+        for key in keys:
+            self.delete(key, noreply)
         return True
 
-    def set_many(self, values, expire=None, noreply=True):
-        for key, value in six.iteritems(values):
-            self.set(key, value, expire, noreply)
-        return []
-
-    set_multi = set_many
+    delete_multi = delete_many
 
     def incr(self, key, value, noreply=False):
         current = self.get(key)
@@ -110,56 +172,19 @@ class MockMemcacheClient(object):
 
     def decr(self, key, value, noreply=False):
         current = self.get(key)
-        if current is None:
-            return
+        present = current is not None
+        if present:
+            self.set(key, current - value, noreply=noreply)
+        return None if noreply or not present else current - value
 
-        self.set(key, current - value, noreply=noreply)
-        return current - value
-
-    def add(self, key, value, expire=None, noreply=True):
+    def touch(self, key, expire=0, noreply=True):
         current = self.get(key)
         present = current is not None
-        if not present:
-            self.set(key, value, expire, noreply)
-        return not present
+        if present:
+            self.set(key, value, expire, noreply=noreply)
+        return True if noreply or present else False
 
-    def delete(self, key, noreply=True):
-        current = self._contents.pop(key, None)
-        present = current is not None
-        return noreply or present
-
-    def delete_many(self, keys, noreply=True):
-        for key in keys:
-            self.delete(key, noreply)
-        return True
-
-    def prepend(self, key, value, expire=0, noreply=None, flags=None):
-        current = self.get(key)
-        if current is not None:
-            if (isinstance(value, six.string_types) and
-                    not isinstance(value, six.binary_type)):
-                try:
-                    value = value.encode(self.encoding)
-                except (UnicodeEncodeError, UnicodeDecodeError):
-                    raise MemcacheIllegalInputError
-            self.set(key, value + current)
-        return True
-
-    def append(self, key, value, expire=0, noreply=None, flags=None):
-        current = self.get(key)
-        if current is not None:
-            if (isinstance(value, six.string_types) and
-                    not isinstance(value, six.binary_type)):
-                try:
-                    value = value.encode(self.encoding)
-                except (UnicodeEncodeError, UnicodeDecodeError):
-                    raise MemcacheIllegalInputError
-            self.set(key, current + value)
-        return True
-
-    delete_multi = delete_many
-
-    def stats(self):
+    def stats(self, *_args):
         # I make no claim that these values make any sense, but the format
         # of the output is the same as for pymemcache.client.Client.stats()
         return {
@@ -180,3 +205,21 @@ class MockMemcacheClient(object):
             "slab_reassign": False,
             "slab_automove": False,
         }
+
+    def cache_memlimit(self, memlimit):
+        return True
+
+    def version(self):
+        return 'MockMemcacheClient'
+
+    def flush_all(self, delay=0, noreply=True):
+        self.clear()
+
+        return noreply or self._contents == {}
+
+    def quit(self):
+        pass
+
+    def clear(self):
+        """Method used to clear/reset mock cache"""
+        self._contents.clear()

--- a/pymemcache/test/utils.py
+++ b/pymemcache/test/utils.py
@@ -204,7 +204,7 @@ class MockMemcacheClient(object):
         current = self.get(key)
         present = current is not None
         if present:
-            self.set(key, value, expire, noreply=noreply)
+            self.set(key, current, expire, noreply=noreply)
         return True if noreply or present else False
 
     def cache_memlimit(self, memlimit):

--- a/pymemcache/test/utils.py
+++ b/pymemcache/test/utils.py
@@ -10,7 +10,7 @@ import time
 import six
 import socket
 
-from pymemcache.exceptions import MemcacheIllegalInputError, MemcacheClientError
+from pymemcache.exceptions import MemcacheClientError, MemcacheIllegalInputError
 from pymemcache.serde import LegacyWrappingSerde
 from pymemcache.client.base import check_key_helper
 


### PR DESCRIPTION
This PR makes `MockMemcacheClient` closer to the implementation of `Client`, namely:

- Added `socket_module`, and `tls_context` parameters `__init__()`
- Added `socket_module`, `sock`, and `tls_context` attributes
- Added `replace()`
- Added `cas()` (which raises `MemcacheClientError` as `cas_enabled` is false for this `MockMemcacheClient`)
- Added `touch()`
- Added `cache_memlimit()`
- Added `version()`
- Added `flush_all()` (internally calling `clear()`)
- Added `quit()`
- Added `close()`
- Refactored `set()` to have default `flags` set to None
- Refactored `set_many()` to follow `Client`'s implementation (always return `[]` when `noreply` is True, else return the keys that were not inserted)
- Refactored `decr()` to have a similar implementation to `incr()` (also taking in account `noreply`'s value)
- Refactored `add()` to take in account `noreply`'s value
- Refactored `get_many()` to support `expire` and `flags`
- Refactored `stats()` to accepts arguments
- Refactored `append()`, `prepend()`, `set_many()`, and `add()` to forward `expire`, `noreply`, and `flags` to their internal call to `set()`
- Set all default value of `noreply` to True when it was None (since in Client, it uses `default_noreply` (set to True), when `noreply` is None)
- Set all default value of `expire` to 0

+ Bumped version to 3.1.1