### PR TITLE
Make PooledClient and HashClient able to use a custom client class

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -1009,6 +1009,9 @@ class PooledClient(object):
     in the pool. Your serde object must therefore be thread-safe.
     """
 
+    #: :class:`Client` class used to create new clients
+    client_class = Client
+
     def __init__(self,
                  server,
                  serde=None,
@@ -1054,20 +1057,20 @@ class PooledClient(object):
                                 key_prefix=self.key_prefix)
 
     def _create_client(self):
-        client = Client(self.server,
-                        serde=self.serde,
-                        connect_timeout=self.connect_timeout,
-                        timeout=self.timeout,
-                        no_delay=self.no_delay,
-                        # We need to know when it fails *always* so that we
-                        # can remove/destroy it from the pool...
-                        ignore_exc=False,
-                        socket_module=self.socket_module,
-                        key_prefix=self.key_prefix,
-                        default_noreply=self.default_noreply,
-                        allow_unicode_keys=self.allow_unicode_keys,
-                        tls_context=self.tls_context)
-        return client
+        return self.client_class(
+            self.server,
+            serde=self.serde,
+            connect_timeout=self.connect_timeout,
+            timeout=self.timeout,
+            no_delay=self.no_delay,
+            # We need to know when it fails *always* so that we
+            # can remove/destroy it from the pool...
+            ignore_exc=False,
+            socket_module=self.socket_module,
+            key_prefix=self.key_prefix,
+            default_noreply=self.default_noreply,
+            allow_unicode_keys=self.allow_unicode_keys,
+            tls_context=self.tls_context)
 
     def close(self):
         self.client_pool.clear()

--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -14,6 +14,8 @@ class HashClient(object):
     """
     A client for communicating with a cluster of memcached servers
     """
+    #: :class:`Client` class used to create new clients
+    client_class = Client
 
     def __init__(
         self,
@@ -112,7 +114,7 @@ class HashClient(object):
                 **self.default_kwargs
             )
         else:
-            client = Client((server, port), **self.default_kwargs)
+            client = self.client_class((server, port), **self.default_kwargs)
 
         self.clients[key] = client
         self.hasher.add_node(key)

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -1213,6 +1213,13 @@ class TestPooledClient(ClientTestMixin, unittest.TestCase):
                                     [b'__FAKE_RESPONSE__\r\n'])
         self._default_noreply_true('flush_all', (), [b'__FAKE_RESPONSE__\r\n'])
 
+    def test_custom_client(self):
+        class MyClient(Client):
+            pass
+        client = PooledClient(('host', 11211))
+        client.client_class = MyClient
+        assert isinstance(client.client_pool.get(), MyClient)
+
 
 class TestMockClient(ClientTestMixin, unittest.TestCase):
     def make_client(self, mock_socket_values, **kwargs):


### PR DESCRIPTION
The user can subclass Client (e.g to add telemetry or logging), and have
their custom client class used by PooledClient and HashClient to create
new clients.