### PR TITLE
Adding a missing assignment on the example of getting a value

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -117,7 +117,7 @@ pymemcache provides a default
 
     client = Client(('localhost', 11211), serde=serde.pickle_serde)
     client.set('key', Foo())
-    result client.get('key')
+    result = client.get('key')
 
 The serializer uses the highest pickle protocol available. In order to make
 sure multiple versions of Python can read the protocol version, you can specify


### PR DESCRIPTION
Reading the documentation I just realize that there is a small detail that can be improved.

There is a missing `=` on one of the examples, it is added on the pull request.