### PR TITLE
Various tweaks to aid implementation of cache backend in Django.

### DIFF
--- a/pymemcache/__init__.py
+++ b/pymemcache/__init__.py
@@ -2,6 +2,7 @@ __version__ = '3.2.0'
 
 from pymemcache.client.base import Client  # noqa
 from pymemcache.client.base import PooledClient  # noqa
+from pymemcache.client.hash import HashClient  # noqa
 
 from pymemcache.exceptions import MemcacheError  # noqa
 from pymemcache.exceptions import MemcacheClientError  # noqa

--- a/pymemcache/client/__init__.py
+++ b/pymemcache/client/__init__.py
@@ -2,6 +2,7 @@
 
 from pymemcache.client.base import Client  # noqa
 from pymemcache.client.base import PooledClient  # noqa
+from pymemcache.client.hash import HashClient  # noqa
 
 from pymemcache.exceptions import MemcacheError  # noqa
 from pymemcache.exceptions import MemcacheClientError  # noqa

--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -316,6 +316,8 @@ class Client(object):
             finally:
                 self.sock = None
 
+    disconnect_all = close
+
     def set(self, key, value, expire=0, noreply=None, flags=None):
         """
         The memcached "set" command.
@@ -1074,6 +1076,8 @@ class PooledClient(object):
 
     def close(self):
         self.client_pool.clear()
+
+    disconnect_all = close
 
     def set(self, key, value, expire=0, noreply=None, flags=None):
         with self.client_pool.get_and_release(destroy_on_fail=True) as client:

--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -1082,9 +1082,8 @@ class PooledClient(object):
 
     def set_many(self, values, expire=0, noreply=None, flags=None):
         with self.client_pool.get_and_release(destroy_on_fail=True) as client:
-            failed = client.set_many(values, expire=expire, noreply=noreply,
-                                     flags=flags)
-            return failed
+            return client.set_many(values, expire=expire, noreply=noreply,
+                                   flags=flags)
 
     set_multi = set_many
 

--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -377,7 +377,6 @@ class HashClient(object):
             client = self._get_client(key)
 
             if client is None:
-                end[key] = False
                 continue
 
             client_batches[client.server].append(key)

--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -327,6 +327,12 @@ class HashClient(object):
 
         return succeeded, failed, None
 
+    def close(self):
+        for client in self.clients.values():
+            self._safely_run_func(client, client.close, False)
+
+    disconnect_all = close
+
     def set(self, key, *args, **kwargs):
         return self._run_cmd('set', key, False, *args, **kwargs)
 
@@ -435,3 +441,7 @@ class HashClient(object):
     def flush_all(self):
         for client in self.clients.values():
             self._safely_run_func(client, client.flush_all, False)
+
+    def quit(self):
+        for client in self.clients.values():
+            self._safely_run_func(client, client.quit, False)

--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -438,5 +438,5 @@ class HashClient(object):
         return self._run_cmd('touch', key, False, *args, **kwargs)
 
     def flush_all(self):
-        for _, client in self.clients.items():
+        for client in self.clients.values():
             self._safely_run_func(client, client.flush_all, False)

--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -1,3 +1,4 @@
+import collections
 import socket
 import time
 import logging
@@ -339,7 +340,7 @@ class HashClient(object):
         return self._run_cmd('decr', key, False, *args, **kwargs)
 
     def set_many(self, values, *args, **kwargs):
-        client_batches = {}
+        client_batches = collections.defaultdict(dict)
         failed = []
 
         for key, value in six.iteritems(values):
@@ -348,9 +349,6 @@ class HashClient(object):
             if client is None:
                 failed.append(key)
                 continue
-
-            if client.server not in client_batches:
-                client_batches[client.server] = {}
 
             client_batches[client.server][key] = value
 
@@ -366,7 +364,7 @@ class HashClient(object):
     set_multi = set_many
 
     def get_many(self, keys, gets=False, *args, **kwargs):
-        client_batches = {}
+        client_batches = collections.defaultdict(list)
         end = {}
 
         for key in keys:
@@ -375,9 +373,6 @@ class HashClient(object):
             if client is None:
                 end[key] = False
                 continue
-
-            if client.server not in client_batches:
-                client_batches[client.server] = []
 
             client_batches[client.server].append(key)
 

--- a/pymemcache/test/test_client_hash.py
+++ b/pymemcache/test/test_client_hash.py
@@ -241,7 +241,7 @@ class TestHashClient(ClientTestMixin, unittest.TestCase):
         )
 
         result = client.get_many(['foo', 'bar'])
-        assert result == {'foo': False, 'bar': False}
+        assert result == {}
 
     def test_ignore_exec_set_many(self):
         values = {

--- a/pymemcache/test/test_client_hash.py
+++ b/pymemcache/test/test_client_hash.py
@@ -159,6 +159,20 @@ class TestHashClient(ClientTestMixin, unittest.TestCase):
         result = client.touch(b'key', 1, noreply=False)
         assert result is True
 
+    def test_close(self):
+        client = self.make_client([])
+        assert all(c.sock is not None for c in client.clients.values())
+        result = client.close()
+        assert result is None
+        assert all(c.sock is None for c in client.clients.values())
+
+    def test_quit(self):
+        client = self.make_client([])
+        assert all(c.sock is not None for c in client.clients.values())
+        result = client.quit()
+        assert result is None
+        assert all(c.sock is None for c in client.clients.values())
+
     def test_no_servers_left(self):
         from pymemcache.client.hash import HashClient
         client = HashClient(


### PR DESCRIPTION
Some of these tweaks will smooth some of the API incompatibilities encountered when implementing django/django#13310.

This also addresses the main wart highlighted in #291.