### PR TITLE
Added support for UNIX sockets in HashClient.

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -37,7 +37,6 @@ VALID_STORE_RESULTS = {
     b'prepend': (b'STORED', b'NOT_STORED'),
     b'cas':     (b'STORED', b'EXISTS', b'NOT_FOUND'),
 }
-VALID_STRING_TYPES = (six.text_type, six.string_types)
 
 
 # Some of the values returned by the "stats" command
@@ -87,9 +86,9 @@ def check_key_helper(key, allow_unicode_keys, key_prefix=b''):
     if allow_unicode_keys:
         if isinstance(key, six.text_type):
             key = key.encode('utf8')
-    elif isinstance(key, VALID_STRING_TYPES):
+    elif isinstance(key, six.string_types):
         try:
-            if isinstance(key, bytes):
+            if isinstance(key, six.binary_type):
                 key = key.decode().encode('ascii')
             else:
                 key = key.encode('ascii')
@@ -264,7 +263,7 @@ class Client(object):
         self.sock = None
         if isinstance(key_prefix, six.text_type):
             key_prefix = key_prefix.encode('ascii')
-        if not isinstance(key_prefix, bytes):
+        if not isinstance(key_prefix, six.binary_type):
             raise TypeError("key_prefix should be bytes.")
         self.key_prefix = key_prefix
         self.default_noreply = default_noreply
@@ -794,7 +793,7 @@ class Client(object):
 
     def _check_integer(self, value, name):
         """Check that a value is an integer and encode it as a binary string"""
-        if not isinstance(value, six.integer_types):  # includes "long" on py2
+        if not isinstance(value, six.integer_types):
             raise MemcacheIllegalInputError(
                 '%s must be integer, got bad value: %r' % (name, value)
             )
@@ -808,7 +807,7 @@ class Client(object):
         The value will be (re)encoded so that we can accept strings or bytes.
         """
         # convert non-binary values to binary
-        if isinstance(cas, (six.integer_types, VALID_STRING_TYPES)):
+        if isinstance(cas, (six.integer_types, six.string_types)):
             try:
                 cas = six.text_type(cas).encode(self.encoding)
             except UnicodeEncodeError:
@@ -1042,7 +1041,7 @@ class PooledClient(object):
         self.allow_unicode_keys = allow_unicode_keys
         if isinstance(key_prefix, six.text_type):
             key_prefix = key_prefix.encode('ascii')
-        if not isinstance(key_prefix, bytes):
+        if not isinstance(key_prefix, six.binary_type):
             raise TypeError("key_prefix should be bytes.")
         self.key_prefix = key_prefix
         self.client_pool = pool.ObjectPool(

--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -120,13 +120,10 @@ class HashClient(object):
         else:
             key = '%s:%s' % server
 
+        _class = PooledClient if self.use_pooling else self.client_class
+        client = _class(server, **self.default_kwargs)
         if self.use_pooling:
-            client = PooledClient(
-                server,
-                **self.default_kwargs
-            )
-        else:
-            client = self.client_class(server, **self.default_kwargs)
+            client.client_class = self.client_class
 
         self.clients[key] = client
         self.hasher.add_node(key)

--- a/pymemcache/test/test_client_hash.py
+++ b/pymemcache/test/test_client_hash.py
@@ -358,6 +358,19 @@ class TestHashClient(ClientTestMixin, unittest.TestCase):
         client.add_server(('host', 11211))
         assert isinstance(client.clients['host:11211'], MyClient)
 
+    def test_custom_client_with_pooling(self):
+        class MyClient(Client):
+            pass
+
+        client = HashClient([], use_pooling=True)
+        client.client_class = MyClient
+        client.add_server(('host', 11211))
+        assert isinstance(client.clients['host:11211'], PooledClient)
+
+        pool = client.clients['host:11211'].client_pool
+        with pool.get_and_release(destroy_on_fail=True) as c:
+            assert isinstance(c, MyClient)
+
     def test_mixed_inet_and_unix_sockets(self):
         servers = [
             '/tmp/pymemcache.{pid}'.format(pid=os.getpid()),

--- a/pymemcache/test/test_client_hash.py
+++ b/pymemcache/test/test_client_hash.py
@@ -5,6 +5,7 @@ from pymemcache import pool
 
 from .test_client import ClientTestMixin, MockSocket
 import unittest
+import os
 import pytest
 import mock
 import socket
@@ -42,7 +43,7 @@ class TestHashClient(ClientTestMixin, unittest.TestCase):
         client_class = 'pymemcache.client.hash.HashClient.client_class'
         with mock.patch(client_class) as internal_client:
             client = HashClient([], timeout=999, key_prefix='foo_bar_baz')
-            client.add_server('127.0.0.1', '11211')
+            client.add_server(('127.0.0.1', '11211'))
 
         assert internal_client.call_args[0][0] == ('127.0.0.1', '11211')
         kwargs = internal_client.call_args[1]
@@ -313,7 +314,7 @@ class TestHashClient(ClientTestMixin, unittest.TestCase):
     @mock.patch("pymemcache.client.hash.HashClient.client_class")
     def test_dead_server_comes_back(self, client_patch):
         client = HashClient([], dead_timeout=0, retry_attempts=0)
-        client.add_server("127.0.0.1", 11211)
+        client.add_server(("127.0.0.1", 11211))
 
         test_client = client_patch.return_value
         test_client.server = ("127.0.0.1", 11211)
@@ -332,7 +333,7 @@ class TestHashClient(ClientTestMixin, unittest.TestCase):
     @mock.patch("pymemcache.client.hash.HashClient.client_class")
     def test_failed_is_retried(self, client_patch):
         client = HashClient([], retry_attempts=1, retry_timeout=0)
-        client.add_server("127.0.0.1", 11211)
+        client.add_server(("127.0.0.1", 11211))
 
         assert client_patch.call_count == 1
 
@@ -354,7 +355,33 @@ class TestHashClient(ClientTestMixin, unittest.TestCase):
 
         client = HashClient([])
         client.client_class = MyClient
-        client.add_server('host', 11211)
+        client.add_server(('host', 11211))
         assert isinstance(client.clients['host:11211'], MyClient)
+
+    def test_mixed_inet_and_unix_sockets(self):
+        servers = [
+            '/tmp/pymemcache.{pid}'.format(pid=os.getpid()),
+            ('127.0.0.1', 11211),
+        ]
+        client = HashClient(servers)
+        assert set(servers) == {c.server for c in client.clients.values()}
+
+    def test_legacy_add_remove_server_signature(self):
+        server = ('127.0.0.1', 11211)
+        client = HashClient([])
+        assert client.clients == {}
+        client.add_server(*server)  # Unpack (host, port) tuple.
+        assert ('%s:%s' % server) in client.clients
+        client._mark_failed_server(server)
+        assert server in client._failed_clients
+        client.remove_server(*server)  # Unpack (host, port) tuple.
+        assert server in client._dead_clients
+        assert server not in client._failed_clients
+
+        # Ensure that server is a string if passing port argument:
+        with pytest.raises(TypeError):
+            client.add_server(server, server[-1])
+        with pytest.raises(TypeError):
+            client.remove_server(server, server[-1])
 
     # TODO: Test failover logic


### PR DESCRIPTION
`HashClient` didn't support using paths to UNIX sockets and passing them to the underlying client.
With these changes it should also be possible to use a mix of UNIX sockets and `(host, port)` 2-tuples.