### PR TITLE
Drop Python version 3.5 and add 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, pypy2, pypy3]
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, pypy2, pypy3]
 
     steps:
     - uses: actions/checkout@v2
@@ -26,7 +26,7 @@ jobs:
         python -m pip install --upgrade pip
         sudo apt-get install libmemcached-dev
     - name: Lint
-      if: matrix.python-version == '2.7' || matrix.python-version == '3.8'
+      if: matrix.python-version == '2.7' || matrix.python-version == '3.9'
       run: |
         pip install codespell flake8
         codespell . --skip=./.*,./pymemcache/test/certs --quiet-level=2

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,10 +12,10 @@ keywords = memcache, client, database
 classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: Implementation :: PyPy
     License :: OSI Approved :: Apache Software License
     Topic :: Database

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,7 @@
+future
 mock
 pytest
 pytest-cov
-gevent==1.3.6; "PyPy" not in platform_python_implementation
+gevent==20.9.0; "PyPy" not in platform_python_implementation
 pylibmc; sys.platform != 'win32'
 python-memcached
-future


### PR DESCRIPTION
- https://pythoninsider.blogspot.com/2020/10/python-35-is-no-longer-supported.html
- https://pythoninsider.blogspot.com/2020/10/python-390-is-now-available-and-you-can.html