### PR TITLE
Move _check_cas() check into cas() method

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -517,6 +517,7 @@ class Client(object):
           the key didn't exist, False if it existed but had a different cas
           value and True if it existed and was changed.
         """
+        cas = self._check_cas(cas)
         return self._store_cmd(b'cas', {key: value}, expire, noreply,
                                flags=flags, cas=cas)[key]
 
@@ -933,7 +934,6 @@ class Client(object):
 
         extra = b''
         if cas is not None:
-            cas = self._check_cas(cas)
             extra += b' ' + cas
         if noreply:
             extra += b' noreply'

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -486,6 +486,9 @@ class TestClient(ClientTestMixin, unittest.TestCase):
     def test_cas_malformed(self):
         client = self.make_client([b'STORED\r\n'])
         with pytest.raises(MemcacheIllegalInputError):
+            client.cas(b'key', b'value', None, noreply=False)
+
+        with pytest.raises(MemcacheIllegalInputError):
             client.cas(b'key', b'value', 'nonintegerstring', noreply=False)
 
         with pytest.raises(MemcacheIllegalInputError):


### PR DESCRIPTION
_check_cas() does a good job of normalizing a CAS value and raising
MemcacheIllegalInputError when fed an invalid value. We were only using
this function in the `cas is not None` path within _store_cmd().

By moving this check into cas() itself, it allows us to also raise
MemcacheIllegalInputError when `cas is None`, which can happen when this
pattern is used for a new key:

    val, cas = c.gets('key')
    c.cas('key', 'value', cas)

See #233