### PR TITLE
Disable IPv6 localhost resolution for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
         codespell . --skip=./.*,./pymemcache/test/certs --quiet-level=2
         flake8 --max-complexity=18 .
         python setup.py check --restructuredtext
+    - name: Disable IPv6 localhost
+      run: |
+        sudo sed -i '/::1/d' /etc/hosts
     - name: Tests
       run: |
         pip install -r test-requirements.txt


### PR DESCRIPTION
GitHub Actions appears to be busted with regard to IPv6-based localhost
resolution between containers. This prevents us from successfully
connecting to our memcached service containers.

We can't resolve this by using `--server` (and `--tls-server`) to
explicitly specify 127.0.0.1 to force IPv4, but that unfortunately
breaks TLS certification verification because that expects 'localhost'.

We should come up with a better solution for this, but for the short
term, this unblocks the failing CI builds.