### PR TITLE
Removing trailing space after a command if there are no arguments.

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -893,8 +893,10 @@ class Client(object):
         remapped_keys = dict(zip(prefixed_keys, keys))
 
         # It is important for all keys to be listed in their original order.
-        # For Memcached Protocol correctness, if the list of prefixed_keys is empty, the name of the command will be immediately followed by the end of line.
-        cmd = name + b' ' + b' '.join(prefixed_keys) + b'\r\n' if prefixed_keys else name + b'\r\n'
+        cmd = name
+        if prefixed_keys:
+            cmd += b' ' + b' '.join(prefixed_keys)
+        cmd += b'\r\n'
 
         try:
             if self.sock is None:

--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -893,7 +893,8 @@ class Client(object):
         remapped_keys = dict(zip(prefixed_keys, keys))
 
         # It is important for all keys to be listed in their original order.
-        cmd = name + b' ' + b' '.join(prefixed_keys) + b'\r\n'
+        # For Memcached Protocol correctness, if the list of prefixed_keys is empty, the name of the command will be immediately followed by the end of line.
+        cmd = name + b' ' + b' '.join(prefixed_keys) + b'\r\n' if prefixed_keys else name + b'\r\n'
 
         try:
             if self.sock is None:

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -889,7 +889,7 @@ class TestClient(ClientTestMixin, unittest.TestCase):
         client = self.make_client([b'STAT fake_stats 1\r\n', b'END\r\n'])
         result = client.stats()
         assert client.sock.send_bufs == [
-            b'stats \r\n'
+            b'stats\r\n'
         ]
         assert result == {b'fake_stats': 1}
 

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -923,7 +923,7 @@ class TestClient(ClientTestMixin, unittest.TestCase):
         ])
         result = client.stats()
         assert client.sock.send_bufs == [
-            b'stats \r\n'
+            b'stats\r\n'
         ]
         expected = {
             b'cmd_get': 2519,


### PR DESCRIPTION
According to the [Memcached Protocol](https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L1151), the no argument form of the stats command should have no trailing spaces. Currently, `b'stats \r\n'` instead of `b'stats\r\n'` is being sent to the socket which leads to a malformed response.