### PR TITLE
Use client.set_many in HashClient.

### DIFF
--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -336,15 +336,12 @@ class HashClient(object):
         succeeded = []
 
         try:
-            for key, value in six.iteritems(values):
-                result = client.set(key, value, *args, **kwargs)
-                if result:
-                    succeeded.append(key)
-                else:
-                    failed.append(key)
+            failed = client.set_many(values, *args, **kwargs)
         except Exception as e:
-            return succeeded, failed, e
+            if not self.ignore_exc:
+                return succeeded, failed, e
 
+        succeeded = [key for key in six.iterkeys(values) if key not in failed]
         return succeeded, failed, None
 
     def close(self):

--- a/pymemcache/test/test_client_hash.py
+++ b/pymemcache/test/test_client_hash.py
@@ -301,7 +301,7 @@ class TestHashClient(ClientTestMixin, unittest.TestCase):
         ], ignore_exc=True)
         result = client.set_many(values, noreply=False)
 
-        assert len(result) == 2
+        assert len(result) == 0
 
     def test_noreply_set_many(self):
         values = {
@@ -336,7 +336,7 @@ class TestHashClient(ClientTestMixin, unittest.TestCase):
         ])
 
         result = client.set_many(values, noreply=False)
-        assert result == ['key2']
+        assert len(result) == 1
 
     def test_server_encoding_pooled(self):
         """


### PR DESCRIPTION
This should fix #319 .

Some unit tests had to be changed since the data returned from `client.set_many` is different from when we iterate over `client.set` multiple times.

- `test_ignore_exec_set_many` - With the old approach if an exception occurred we could mark the individual key as failed and keep going. With `set_many` we only get a list of failed keys if no exception was thrown. Instead if `ignore_exc` is set, I chose to mark all keys as set.
- `test_set_many_unix` - It relies on the ordering of keys in a dict, which is unordered. I changed it from checking if a specific key failed, to just check a single key failed.

I don't have all the python interpreters installed on my machine, but tests pass for the following envs in tox:

- `py27`
- `py36`
- `py37`
- `py27-flake8`
- `py39-flake8`

`py39` tests failed because it was compiled without sqlite.

If I missed something or there is anything else that needs doing, please let me know.