### PR TITLE
Drop python support for 2.7, 3.4 and 3.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9, pypy2, pypy3]
+        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
 
     steps:
     - uses: actions/checkout@v2
@@ -26,7 +26,7 @@ jobs:
         python -m pip install --upgrade pip
         sudo apt-get install libmemcached-dev
     - name: Lint
-      if: matrix.python-version == '2.7' || matrix.python-version == '3.9'
+      if: matrix.python-version == '3.9'
       run: |
         pip install tox tox-gh-actions
         tox -e flake8

--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -99,10 +99,7 @@ def check_key_helper(key, allow_unicode_keys, key_prefix=b''):
             key = key.encode('utf8')
     elif isinstance(key, str):
         try:
-            if isinstance(key, bytes):
-                key = key.decode().encode('ascii')
-            else:
-                key = key.encode('ascii')
+            key = key.encode('ascii')
         except (UnicodeEncodeError, UnicodeDecodeError):
             raise MemcacheIllegalInputError("Non-ASCII key: %r" % key)
 

--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -14,7 +14,6 @@
 import errno
 import platform
 import socket
-import six
 
 from pymemcache import pool
 
@@ -71,16 +70,16 @@ def _parse_hex(value):
 
 STAT_TYPES = {
     # General stats
-    b'version': six.binary_type,
+    b'version': bytes,
     b'rusage_user': _parse_float,
     b'rusage_system': _parse_float,
     b'hash_is_expanding': _parse_bool_int,
     b'slab_reassign_running': _parse_bool_int,
 
     # Settings stats
-    b'inter': six.binary_type,
+    b'inter': bytes,
     b'growth_factor': float,
-    b'stat_key_prefix': six.binary_type,
+    b'stat_key_prefix': bytes,
     b'umask': _parse_hex,
     b'detail_enabled': _parse_bool_int,
     b'cas_enabled': _parse_bool_int,
@@ -96,11 +95,11 @@ STAT_TYPES = {
 def check_key_helper(key, allow_unicode_keys, key_prefix=b''):
     """Checks key and add key_prefix."""
     if allow_unicode_keys:
-        if isinstance(key, six.text_type):
+        if isinstance(key, str):
             key = key.encode('utf8')
-    elif isinstance(key, six.string_types):
+    elif isinstance(key, str):
         try:
-            if isinstance(key, six.binary_type):
+            if isinstance(key, bytes):
                 key = key.decode().encode('ascii')
             else:
                 key = key.encode('ascii')
@@ -126,7 +125,7 @@ def normalize_server_spec(server):
         return server
     if isinstance(server, list):
         return tuple(server)  # Assume [host, port] provided.
-    if not isinstance(server, six.string_types):
+    if not isinstance(server, str):
         raise ValueError('Unknown server provided: %r' % server)
     if server.startswith('unix:'):
         return server[5:]
@@ -142,7 +141,7 @@ def normalize_server_spec(server):
     return (host, port)
 
 
-class KeepaliveOpts(object):
+class KeepaliveOpts:
     """
     A configuration structure to define the socket keepalive.
 
@@ -176,7 +175,7 @@ class KeepaliveOpts(object):
         self.cnt = cnt
 
 
-class Client(object):
+class Client:
     """
     A client for a single memcached server.
 
@@ -358,9 +357,9 @@ class Client(object):
                     "of structure."
                 )
         self.sock = None
-        if isinstance(key_prefix, six.text_type):
+        if isinstance(key_prefix, str):
             key_prefix = key_prefix.encode('ascii')
-        if not isinstance(key_prefix, six.binary_type):
+        if not isinstance(key_prefix, bytes):
             raise TypeError("key_prefix should be bytes.")
         self.key_prefix = key_prefix
         self.default_noreply = default_noreply
@@ -483,7 +482,7 @@ class Client(object):
         if noreply is None:
             noreply = self.default_noreply
         result = self._store_cmd(b'set', values, expire, noreply, flags=flags)
-        return [k for k, v in six.iteritems(result) if not v]
+        return [k for k, v in result.items() if not v]
 
     set_multi = set_many
 
@@ -824,7 +823,7 @@ class Client(object):
         """
         result = self._fetch_cmd(b'stats', args, False)
 
-        for key, value in six.iteritems(result):
+        for key, value in result.items():
             converter = STAT_TYPES.get(key, int)
             try:
                 result[key] = converter(value)
@@ -941,12 +940,12 @@ class Client(object):
 
     def _check_integer(self, value, name):
         """Check that a value is an integer and encode it as a binary string"""
-        if not isinstance(value, six.integer_types):
+        if not isinstance(value, int):
             raise MemcacheIllegalInputError(
-                '%s must be integer, got bad value: %r' % (name, value)
+                f'{name} must be integer, got bad value: {value!r}'
             )
 
-        return six.text_type(value).encode(self.encoding)
+        return str(value).encode(self.encoding)
 
     def _check_cas(self, cas):
         """Check that a value is a valid input for 'cas' -- either an int or a
@@ -955,13 +954,13 @@ class Client(object):
         The value will be (re)encoded so that we can accept strings or bytes.
         """
         # convert non-binary values to binary
-        if isinstance(cas, (six.integer_types, six.string_types)):
+        if isinstance(cas, (int, str)):
             try:
-                cas = six.text_type(cas).encode(self.encoding)
+                cas = str(cas).encode(self.encoding)
             except UnicodeEncodeError:
                 raise MemcacheIllegalInputError(
                     'non-ASCII cas value: %r' % cas)
-        elif not isinstance(cas, six.binary_type):
+        elif not isinstance(cas, bytes):
             raise MemcacheIllegalInputError(
                 'cas must be integer, string, or bytes, got bad value: %r' % cas
             )
@@ -987,7 +986,7 @@ class Client(object):
             try:
                 _, key, flags, size = line.split()
             except Exception as e:
-                raise ValueError("Unable to parse line %s: %s" % (line, e))
+                raise ValueError(f"Unable to parse line {line}: {e}")
 
         value = None
         try:
@@ -1062,7 +1061,7 @@ class Client(object):
             extra += b' noreply'
         expire = self._check_integer(expire, "expire")
 
-        for key, data in six.iteritems(values):
+        for key, data in values.items():
             # must be able to reliably map responses back to the original order
             keys.append(key)
 
@@ -1074,17 +1073,17 @@ class Client(object):
             if flags is not None:
                 data_flags = flags
 
-            if not isinstance(data, six.binary_type):
+            if not isinstance(data, bytes):
                 try:
-                    data = six.text_type(data).encode(self.encoding)
+                    data = str(data).encode(self.encoding)
                 except UnicodeEncodeError as e:
                     raise MemcacheIllegalInputError(
                             "Data values must be binary-safe: %s" % e)
 
             cmds.append(name + b' ' + key + b' ' +
-                        six.text_type(data_flags).encode(self.encoding) +
+                        str(data_flags).encode(self.encoding) +
                         b' ' + expire +
-                        b' ' + six.text_type(len(data)).encode(self.encoding) +
+                        b' ' + str(len(data)).encode(self.encoding) +
                         extra + b'\r\n' + data + b'\r\n')
 
         if self.sock is None:
@@ -1155,7 +1154,7 @@ class Client(object):
         self.delete(key, noreply=True)
 
 
-class PooledClient(object):
+class PooledClient:
     """A thread-safe pool of clients (with the same client api).
 
     Args:
@@ -1208,9 +1207,9 @@ class PooledClient(object):
         self.socket_keepalive = socket_keepalive
         self.default_noreply = default_noreply
         self.allow_unicode_keys = allow_unicode_keys
-        if isinstance(key_prefix, six.text_type):
+        if isinstance(key_prefix, str):
             key_prefix = key_prefix.encode('ascii')
-        if not isinstance(key_prefix, six.binary_type):
+        if not isinstance(key_prefix, bytes):
             raise TypeError("key_prefix should be bytes.")
         self.key_prefix = key_prefix
         self.client_pool = pool.ObjectPool(
@@ -1490,6 +1489,6 @@ def _recv(sock, size):
     while True:
         try:
             return sock.recv(size)
-        except IOError as e:
+        except OSError as e:
             if e.errno != errno.EINTR:
                 raise

--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -2,7 +2,6 @@ import collections
 import socket
 import time
 import logging
-import six
 
 from pymemcache.client.base import (
     Client,
@@ -16,7 +15,7 @@ from pymemcache.exceptions import MemcacheError
 logger = logging.getLogger(__name__)
 
 
-class HashClient(object):
+class HashClient:
     """
     A client for communicating with a cluster of memcached servers
     """
@@ -125,7 +124,7 @@ class HashClient(object):
         # To maintain backward compatibility, if a port is provided, assume
         # that server wasn't provided as a (host, port) tuple.
         if port is not None:
-            if not isinstance(server, six.string_types):
+            if not isinstance(server, str):
                 raise TypeError('Server must be a string when passing port.')
             server = (server, port)
 
@@ -142,7 +141,7 @@ class HashClient(object):
         # To maintain backward compatibility, if a port is provided, assume
         # that server wasn't provided as a (host, port) tuple.
         if port is not None:
-            if not isinstance(server, six.string_types):
+            if not isinstance(server, str):
                 raise TypeError('Server must be a string when passing port.')
             server = (server, port)
 
@@ -216,7 +215,7 @@ class HashClient(object):
 
         # Connecting to the server fail, we should enter
         # retry mode
-        except socket.error:
+        except OSError:
             self._mark_failed_server(client.server)
 
             # if we haven't enabled ignore_exc, don't move on gracefully, just
@@ -275,7 +274,7 @@ class HashClient(object):
 
         # Connecting to the server fail, we should enter
         # retry mode
-        except socket.error:
+        except OSError:
             self._mark_failed_server(client.server)
 
             # if we haven't enabled ignore_exc, don't move on gracefully, just
@@ -370,7 +369,7 @@ class HashClient(object):
         client_batches = collections.defaultdict(dict)
         failed = []
 
-        for key, value in six.iteritems(values):
+        for key, value in values.items():
             client = self._get_client(key)
 
             if client is None:

--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -344,7 +344,7 @@ class HashClient:
             if not self.ignore_exc:
                 return succeeded, failed, e
 
-        succeeded = [key for key in six.iterkeys(values) if key not in failed]
+        succeeded = [key for key in values if key not in failed]
         return succeeded, failed, None
 
     def close(self):

--- a/pymemcache/client/rendezvous.py
+++ b/pymemcache/client/rendezvous.py
@@ -35,8 +35,7 @@ class RendezvousHash:
         winner = None
 
         for node in self.nodes:
-            score = self.hash_function(
-                f"{node}-{key}")
+            score = self.hash_function(f"{node}-{key}")
 
             if score > high_score:
                 (high_score, winner) = (score, node)

--- a/pymemcache/client/rendezvous.py
+++ b/pymemcache/client/rendezvous.py
@@ -1,7 +1,7 @@
 from pymemcache.client.murmur3 import murmur3_32
 
 
-class RendezvousHash(object):
+class RendezvousHash:
     """
         Implements the Highest Random Weight (HRW) hashing algorithm most
         commonly referred to as rendezvous hashing.
@@ -36,7 +36,7 @@ class RendezvousHash(object):
 
         for node in self.nodes:
             score = self.hash_function(
-                "%s-%s" % (node, key))
+                f"{node}-{key}")
 
             if score > high_score:
                 (high_score, winner) = (score, node)

--- a/pymemcache/fallback.py
+++ b/pymemcache/fallback.py
@@ -43,7 +43,7 @@ Best Practices:
 """
 
 
-class FallbackClient(object):
+class FallbackClient:
     def __init__(self, caches):
         assert len(caches) > 0
         self.caches = caches

--- a/pymemcache/pool.py
+++ b/pymemcache/pool.py
@@ -18,10 +18,8 @@ import sys
 import threading
 import time
 
-import six
 
-
-class ObjectPool(object):
+class ObjectPool:
     """A pool of objects that release/creates/destroys as needed."""
 
     def __init__(self, obj_creator,
@@ -37,7 +35,7 @@ class ObjectPool(object):
             self._lock = lock_generator()
         self._after_remove = after_remove
         max_size = max_size or 2 ** 31
-        if not isinstance(max_size, six.integer_types) or max_size < 0:
+        if not isinstance(max_size, int) or max_size < 0:
             raise ValueError('"max_size" must be a positive integer')
         self.max_size = max_size
         self.idle_timeout = idle_timeout
@@ -62,7 +60,7 @@ class ObjectPool(object):
                 self.release(obj)
             else:
                 self.destroy(obj)
-            six.reraise(exc_info[0], exc_info[1], exc_info[2])
+            raise exc_info[1].with_traceback(exc_info[2])
         self.release(obj)
 
     def get(self):

--- a/pymemcache/serde.py
+++ b/pymemcache/serde.py
@@ -15,8 +15,7 @@
 from functools import partial
 import logging
 from io import BytesIO
-import six
-from six.moves import cPickle as pickle
+import pickle
 
 try:
     long_type = long  # noqa
@@ -49,16 +48,12 @@ def _python_memcache_serializer(key, value, pickle_version=None):
     if value_type is bytes:
         pass
 
-    elif value_type is six.text_type:
+    elif value_type is str:
         flags |= FLAG_TEXT
         value = value.encode('utf8')
 
     elif value_type is int:
         flags |= FLAG_INTEGER
-        value = "%d" % value
-
-    elif six.PY2 and value_type is long_type:
-        flags |= FLAG_LONG
         value = "%d" % value
 
     else:
@@ -90,10 +85,7 @@ def python_memcache_deserializer(key, value, flags):
         return int(value)
 
     elif flags & FLAG_LONG:
-        if six.PY3:
-            return int(value)
-        else:
-            return long_type(value)
+        return int(value)
 
     elif flags & FLAG_PICKLE:
         try:
@@ -107,7 +99,7 @@ def python_memcache_deserializer(key, value, flags):
     return value
 
 
-class PickleSerde(object):
+class PickleSerde:
     """
     An object which implements the serialization/deserialization protocol for
     :py:class:`pymemcache.client.base.Client` and its descendants using the
@@ -134,7 +126,7 @@ class PickleSerde(object):
         return python_memcache_deserializer(key, value, flags)
 
 
-class LegacyWrappingSerde(object):
+class LegacyWrappingSerde:
     """
     This class defines how to wrap legacy de/serialization functions into a
     'serde' object which implements '.serialize' and '.deserialize' methods.

--- a/pymemcache/serde.py
+++ b/pymemcache/serde.py
@@ -17,12 +17,6 @@ import logging
 from io import BytesIO
 import pickle
 
-try:
-    long_type = long  # noqa
-except NameError:
-    long_type = None
-
-
 FLAG_BYTES = 0
 FLAG_PICKLE = 1 << 0
 FLAG_INTEGER = 1 << 1

--- a/pymemcache/test/conftest.py
+++ b/pymemcache/test/conftest.py
@@ -92,7 +92,7 @@ def pytest_generate_tests(metafunc):
 
         class HashClientSingle(HashClient):
             def __init__(self, server, *args, **kwargs):
-                super(HashClientSingle, self).__init__(
+                super().__init__(
                     [server], *args, **kwargs
                 )
 

--- a/pymemcache/test/test_benchmark.py
+++ b/pymemcache/test/test_benchmark.py
@@ -78,7 +78,7 @@ def benchmark(count, func, *args, **kwargs):
 
 @pytest.mark.benchmark()
 def test_bench_get(request, client, pairs, count):
-    key, value = next(pairs.items())
+    key, value = next(pairs)
     client.set(key, value)
     benchmark(count, client.get, key)
 
@@ -102,7 +102,7 @@ def test_bench_set_multi(request, client, pairs, count):
 
 @pytest.mark.benchmark()
 def test_bench_delete(request, client, pairs, count):
-    benchmark(count, client.delete, next(pairs.keys()))
+    benchmark(count, client.delete, next(pairs))
 
 
 @pytest.mark.benchmark()

--- a/pymemcache/test/test_benchmark.py
+++ b/pymemcache/test/test_benchmark.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import six
 import time
 import pytest
 
@@ -45,13 +44,13 @@ def client(request, host, port):
     if request.param == "pylibmc":
         if not HAS_PYLIBMC:
             pytest.skip("requires pylibmc")
-        client = pylibmc.Client(['{0}:{1}'.format(host, port)])
+        client = pylibmc.Client([f'{host}:{port}'])
         client.behaviors = {"tcp_nodelay": True}
 
     elif request.param == "memcache":
         if not HAS_MEMCACHE:
             pytest.skip("requires python-memcached")
-        client = memcache.Client(['{0}:{1}'.format(host, port)])
+        client = memcache.Client([f'{host}:{port}'])
 
     elif request.param == "pymemcache":
         if not HAS_PYMEMCACHE:
@@ -59,7 +58,7 @@ def client(request, host, port):
         client = pymemcache.client.Client((host, port))
 
     else:
-        pytest.skip("unknown library {0}".format(request.param))
+        pytest.skip(f"unknown library {request.param}")
 
     client.flush_all()
     return client
@@ -79,14 +78,14 @@ def benchmark(count, func, *args, **kwargs):
 
 @pytest.mark.benchmark()
 def test_bench_get(request, client, pairs, count):
-    key, value = six.next(six.iteritems(pairs))
+    key, value = next(pairs.items())
     client.set(key, value)
     benchmark(count, client.get, key)
 
 
 @pytest.mark.benchmark()
 def test_bench_set(request, client, pairs, count):
-    key, value = six.next(six.iteritems(pairs))
+    key, value = next(pairs.items())
     benchmark(count, client.set, key, value)
 
 
@@ -103,7 +102,7 @@ def test_bench_set_multi(request, client, pairs, count):
 
 @pytest.mark.benchmark()
 def test_bench_delete(request, client, pairs, count):
-    benchmark(count, client.delete, six.next(six.iterkeys(pairs)))
+    benchmark(count, client.delete, next(pairs.keys()))
 
 
 @pytest.mark.benchmark()

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import bytes as newbytes
-
 import collections
 import errno
 import functools
@@ -223,22 +221,6 @@ class ClientTestMixin:
         # unit test for set operation with parameter flags
         client = self.make_client([b'STORED\r\n'], encoding='utf-8')
         result = client.set(b'key', b'value', noreply=False, flags=0x00000030)
-        assert result is True
-
-    def test_set_future(self):
-        client = self.make_client([b'STORED\r\n'])
-        result = client.set(newbytes(b'key'), newbytes(b'value'), noreply=False)
-        assert result is True
-
-        # unit test for encoding passed in __init__()
-        client = self.make_client([b'STORED\r\n'], encoding='utf-8')
-        result = client.set(newbytes(b'key'), newbytes(b'value'), noreply=False)
-        assert result is True
-
-        # unit test for set operation with parameter flags
-        client = self.make_client([b'STORED\r\n'], encoding='utf-8')
-        result = client.set(newbytes(b'key'), newbytes(b'value'), noreply=False,
-                            flags=0x00000030)
         assert result is True
 
     def test_set_unicode_key(self):

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -1,5 +1,4 @@
 # Copyright 2012 Pinterest.com
-# -*- coding: utf-8 -*-
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,8 +19,8 @@ import errno
 import functools
 import json
 import os
-import mock
 import platform
+from unittest import mock
 import re
 import socket
 import sys
@@ -92,7 +91,7 @@ def test_check_key_helper():
     assert check_key_helper("", True) == b""
 
 
-class MockSocket(object):
+class MockSocket:
     def __init__(self, recv_bufs, connect_failure=None, close_failure=None):
         self.recv_bufs = collections.deque(recv_bufs)
         self.send_bufs = []
@@ -134,7 +133,7 @@ class MockSocket(object):
         self.socket_options.append((level, option, value))
 
 
-class MockUnixSocketServer(object):
+class MockUnixSocketServer:
     def __init__(self, socket_path):
         if os.path.exists(socket_path):
             os.remove(socket_path)
@@ -151,7 +150,7 @@ class MockUnixSocketServer(object):
         os.remove(self.socket_path)
 
 
-class MockSocketModule(object):
+class MockSocketModule:
     def __init__(self, connect_failure=None, close_failure=None):
         self.connect_failure = connect_failure
         self.close_failure = close_failure
@@ -190,7 +189,7 @@ class CustomizedClient(Client):
 
 
 @pytest.mark.unit()
-class ClientTestMixin(object):
+class ClientTestMixin:
     def make_client(self, mock_socket_values, **kwargs):
         client = Client(None, **kwargs)
         # mock out client._connect() rather than hard-settting client.sock to
@@ -246,7 +245,7 @@ class ClientTestMixin(object):
         client = self.make_client([b''])
 
         def _set():
-            client.set(u'\u0FFF', b'value', noreply=False)
+            client.set('\u0FFF', b'value', noreply=False)
 
         with pytest.raises(MemcacheIllegalInputError):
             _set()
@@ -254,7 +253,7 @@ class ClientTestMixin(object):
     def test_set_unicode_key_ok(self):
         client = self.make_client([b'STORED\r\n'], allow_unicode_keys=True)
 
-        result = client.set(u'\u0FFF', b'value', noreply=False)
+        result = client.set('\u0FFF', b'value', noreply=False)
         assert result is True
 
     def test_set_unicode_key_ok_snowman(self):
@@ -285,7 +284,7 @@ class ClientTestMixin(object):
         client = self.make_client([b''])
 
         def _set():
-            client.set(b'key', u'\u0FFF', noreply=False)
+            client.set(b'key', '\u0FFF', noreply=False)
 
         with pytest.raises(MemcacheIllegalInputError):
             _set()
@@ -434,7 +433,7 @@ class ClientTestMixin(object):
         client = self.make_client([b''])
 
         def _get():
-            client.get(u'\u0FFF')
+            client.get('\u0FFF')
 
         with pytest.raises(MemcacheIllegalInputError):
             _get()
@@ -560,7 +559,7 @@ class TestClient(ClientTestMixin, unittest.TestCase):
 
         with pytest.raises(MemcacheIllegalInputError):
             # non-ASCII digit
-            client.cas(b'key', b'value', u'⁰', noreply=False)
+            client.cas(b'key', b'value', '⁰', noreply=False)
 
     def test_cas_stored(self):
         client = self.make_client([b'STORED\r\n'])
@@ -769,7 +768,7 @@ class TestClient(ClientTestMixin, unittest.TestCase):
         assert result is False
 
     def test_serialization(self):
-        class JsonSerde(object):
+        class JsonSerde:
             def serialize(self, key, value):
                 return json.dumps(value).encode('ascii'), 0
 
@@ -922,7 +921,7 @@ class TestClient(ClientTestMixin, unittest.TestCase):
     def test_set_key_with_noninteger_expire(self):
         client = self.make_client([b''])
 
-        class _OneLike(object):
+        class _OneLike:
             """object that looks similar to the int 1"""
             def __str__(self):
                 return "1"
@@ -1080,7 +1079,7 @@ class TestClient(ClientTestMixin, unittest.TestCase):
             client.get('my☃'*150)
 
         with pytest.raises(MemcacheClientError):
-            client.get(u'\u0FFF'*150)
+            client.get('\u0FFF'*150)
 
     def test_key_contains_space(self):
         client = self.make_client([b'END\r\n'])
@@ -1091,7 +1090,7 @@ class TestClient(ClientTestMixin, unittest.TestCase):
         client = self.make_client([b'END\r\n'])
 
         with pytest.raises(MemcacheClientError):
-            client.get(u'\u3053\u3093\u306b\u3061\u306f')
+            client.get('\u3053\u3093\u306b\u3061\u306f')
 
     def _default_noreply_false(self, cmd, args, response):
         client = self.make_client(response, default_noreply=False)
@@ -1225,7 +1224,7 @@ class TestClientSocketConnect(unittest.TestCase):
                                                socket.TCP_NODELAY, 1)]
 
     def test_socket_connect_unix(self):
-        server = '/tmp/pymemcache.{pid}'.format(pid=os.getpid())
+        server = f'/tmp/pymemcache.{os.getpid()}'
 
         with MockUnixSocketServer(server):
             client = Client(server)
@@ -1434,7 +1433,7 @@ class TestMockClient(ClientTestMixin, unittest.TestCase):
         assert result == b'value'
 
     def test_deserialization(self):
-        class JsonSerde(object):
+        class JsonSerde:
             def serialize(self, key, value):
                 if isinstance(value, dict):
                     return json.dumps(value).encode('UTF-8'), 1

--- a/pymemcache/test/test_client_hash.py
+++ b/pymemcache/test/test_client_hash.py
@@ -7,7 +7,7 @@ from .test_client import ClientTestMixin, MockSocket
 import unittest
 import os
 import pytest
-import mock
+from unittest import mock
 import socket
 
 
@@ -27,7 +27,7 @@ class TestHashClient(ClientTestMixin, unittest.TestCase):
         ip = '127.0.0.1'
 
         for vals in mock_socket_values:
-            s = '%s:%s' % (ip, current_port)
+            s = f'{ip}:{current_port}'
             c = self.make_client_pool(
                 (ip, current_port),
                 vals,
@@ -427,12 +427,12 @@ class TestHashClient(ClientTestMixin, unittest.TestCase):
 
     def test_mixed_inet_and_unix_sockets(self):
         expected = {
-            '/tmp/pymemcache.{pid}'.format(pid=os.getpid()),
+            f'/tmp/pymemcache.{os.getpid()}',
             ('127.0.0.1', 11211),
             ('::1', 11211),
         }
         client = HashClient([
-            '/tmp/pymemcache.{pid}'.format(pid=os.getpid()),
+            f'/tmp/pymemcache.{os.getpid()}',
             '127.0.0.1',
             '127.0.0.1:11211',
             '[::1]',

--- a/pymemcache/test/test_client_retry.py
+++ b/pymemcache/test/test_client_retry.py
@@ -2,8 +2,8 @@
 
 import functools
 import unittest
+from unittest import mock
 
-import mock
 import pytest
 
 from .test_client import ClientTestMixin, MockSocket

--- a/pymemcache/test/test_integration.py
+++ b/pymemcache/test/test_integration.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from builtins import bytes as newbytes
-
 from collections import defaultdict
 import json
 import pytest
@@ -57,18 +55,6 @@ def test_get_set(client_class, host, port, socket_module):
     value = b'value'
     key2 = b'key2'
     value2 = b'value2'
-    get_set_helper(client, key, value, key2, value2)
-
-
-@pytest.mark.integration()
-def test_get_set_newbytes(client_class, host, port, socket_module):
-    client = client_class((host, port), socket_module=socket_module)
-    client.flush_all()
-
-    key = newbytes(b'key3')
-    value = b'value3'
-    key2 = newbytes(b'key4')
-    value2 = b'value4'
     get_set_helper(client, key, value, key2, value2)
 
 

--- a/pymemcache/test/test_integration.py
+++ b/pymemcache/test/test_integration.py
@@ -1,5 +1,4 @@
 # Copyright 2012 Pinterest.com
-# -*- coding: utf-8 -*-
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +17,6 @@ from builtins import bytes as newbytes
 from collections import defaultdict
 import json
 import pytest
-import six
 
 from pymemcache.client.base import Client
 from pymemcache.exceptions import (
@@ -80,7 +78,7 @@ def test_get_set_unicode_key(client_class, host, port, socket_module):
                           allow_unicode_keys=True)
     client.flush_all()
 
-    key = u"こんにちは"
+    key = "こんにちは"
     value = b'hello'
     key2 = 'my☃'
     value2 = b'value2'
@@ -255,7 +253,7 @@ def test_misc(client_class, host, port, socket_module):
 
 @pytest.mark.integration()
 def test_serialization_deserialization(host, port, socket_module):
-    class JsonSerde(object):
+    class JsonSerde:
         def serialize(self, key, value):
             return json.dumps(value).encode('ascii'), 1
 
@@ -287,15 +285,15 @@ def serde_serialization_helper(client_class, host, port,
     client.flush_all()
 
     check(b'byte string')
-    check(u'unicode string')
+    check('unicode string')
     check('olé')
-    check(u'olé')
+    check('olé')
     check(1)
     check(123123123123123123123)
     check({'a': 'pickle'})
-    check([u'one pickle', u'two pickle'])
+    check(['one pickle', 'two pickle'])
     testdict = defaultdict(int)
-    testdict[u'one pickle']
+    testdict['one pickle']
     testdict[b'two pickle']
     check(testdict)
 
@@ -346,19 +344,19 @@ def test_errors(client_class, host, port, socket_module):
         _key_too_long()
 
     def _unicode_key_in_set():
-        client.set(six.u('\u0FFF'), b'value', noreply=False)
+        client.set('\u0FFF', b'value', noreply=False)
 
     with pytest.raises(MemcacheClientError):
         _unicode_key_in_set()
 
     def _unicode_key_in_get():
-        client.get(six.u('\u0FFF'))
+        client.get('\u0FFF')
 
     with pytest.raises(MemcacheClientError):
         _unicode_key_in_get()
 
     def _unicode_value_in_set():
-        client.set(b'key', six.u('\u0FFF'), noreply=False)
+        client.set(b'key', '\u0FFF', noreply=False)
 
     with pytest.raises(MemcacheClientError):
         _unicode_value_in_set()

--- a/pymemcache/test/test_serde.py
+++ b/pymemcache/test/test_serde.py
@@ -1,13 +1,11 @@
-# -*- coding: utf-8 -*-
 from unittest import TestCase
 
 from pymemcache.serde import (pickle_serde,
                               PickleSerde,
                               FLAG_BYTES,
-                              FLAG_PICKLE, FLAG_INTEGER, FLAG_LONG, FLAG_TEXT)
+                              FLAG_PICKLE, FLAG_INTEGER, FLAG_TEXT)
 import pytest
-import six
-from six.moves import cPickle as pickle
+import pickle
 
 
 class CustomInt(int):
@@ -30,8 +28,8 @@ class TestSerde(TestCase):
 
         # pymemcache stores values as byte strings, so we immediately the value
         # if needed so deserialized works as it would with a real server
-        if not isinstance(serialized, six.binary_type):
-            serialized = six.text_type(serialized).encode('ascii')
+        if not isinstance(serialized, bytes):
+            serialized = str(serialized).encode('ascii')
 
         deserialized = self.serde.deserialize(b'key', serialized, flags)
         assert deserialized == value
@@ -41,8 +39,8 @@ class TestSerde(TestCase):
         self.check(b'\xc2\xa3 $ \xe2\x82\xac', FLAG_BYTES)  # £ $ €
 
     def test_unicode(self):
-        self.check(u'value', FLAG_TEXT)
-        self.check(u'£ $ €', FLAG_TEXT)
+        self.check('value', FLAG_TEXT)
+        self.check('£ $ €', FLAG_TEXT)
 
     def test_int(self):
         self.check(1, FLAG_INTEGER)
@@ -50,10 +48,7 @@ class TestSerde(TestCase):
     def test_long(self):
         # long only exists with Python 2, so we're just testing for another
         # integer with Python 3
-        if six.PY2:
-            expected_flags = FLAG_LONG
-        else:
-            expected_flags = FLAG_INTEGER
+        expected_flags = FLAG_INTEGER
         self.check(123123123123123123123, expected_flags)
 
     def test_pickleable(self):

--- a/pymemcache/test/test_serde.py
+++ b/pymemcache/test/test_serde.py
@@ -45,12 +45,6 @@ class TestSerde(TestCase):
     def test_int(self):
         self.check(1, FLAG_INTEGER)
 
-    def test_long(self):
-        # long only exists with Python 2, so we're just testing for another
-        # integer with Python 3
-        expected_flags = FLAG_INTEGER
-        self.check(123123123123123123123, expected_flags)
-
     def test_pickleable(self):
         self.check({'a': 'dict'}, FLAG_PICKLE)
 

--- a/pymemcache/test/test_utils.py
+++ b/pymemcache/test/test_utils.py
@@ -1,4 +1,3 @@
-import six
 import pytest
 
 from pymemcache.test.utils import MockMemcacheClient
@@ -16,10 +15,10 @@ def test_get_set():
 @pytest.mark.unit()
 def test_get_set_unicide_key():
     client = MockMemcacheClient()
-    assert client.get(u"hello") is None
+    assert client.get("hello") is None
 
     client.set(b"hello", 12)
-    assert client.get(u"hello") == 12
+    assert client.get("hello") == 12
 
 
 @pytest.mark.unit()
@@ -42,8 +41,7 @@ def test_get_many_set_many():
     assert result == {b"h": 1}
 
     # Convert keys into bytes
-    d = dict((k.encode('ascii'), v)
-             for k, v in six.iteritems(dict(h=1, e=2, z=3)))
+    d = {k.encode('ascii'): v for k, v in dict(h=1, e=2, z=3).items()}
     client.set_many(d)
     assert client.get_many([b"h", b"e", b"z", b"o"]) == d
 
@@ -62,10 +60,8 @@ def test_get_many_set_many_non_ascii_values():
     assert result == {b"h": non_ascii_1}
 
     # Convert keys into bytes
-    d = dict((k.encode('ascii'), v)
-             for k, v in six.iteritems(
-                dict(h=non_ascii_1, e=non_ascii_2, z=non_ascii_3)
-             ))
+    d = {k.encode('ascii'): v
+         for k, v in dict(h=non_ascii_1, e=non_ascii_2, z=non_ascii_3).items()}
     client.set_many(d)
     assert client.get_many([b"h", b"e", b"z", b"o"]) == d
 

--- a/pymemcache/test/utils.py
+++ b/pymemcache/test/utils.py
@@ -7,7 +7,6 @@ This module is considered public API.
 
 import time
 
-import six
 import socket
 
 from pymemcache.exceptions import MemcacheClientError, MemcacheIllegalInputError
@@ -15,7 +14,7 @@ from pymemcache.serde import LegacyWrappingSerde
 from pymemcache.client.base import check_key_helper
 
 
-class MockMemcacheClient(object):
+class MockMemcacheClient:
     """
     A (partial) in-memory mock for Clients.
 
@@ -85,8 +84,8 @@ class MockMemcacheClient(object):
 
     def set(self, key, value, expire=0, noreply=True, flags=None):
         key = self.check_key(key)
-        if (isinstance(value, six.string_types) and
-                not isinstance(value, six.binary_type)):
+        if (isinstance(value, str) and
+                not isinstance(value, bytes)):
             try:
                 value = value.encode(self.encoding)
             except (UnicodeEncodeError, UnicodeDecodeError):
@@ -102,7 +101,7 @@ class MockMemcacheClient(object):
 
     def set_many(self, values, expire=0, noreply=True, flags=None):
         result = []
-        for key, value in six.iteritems(values):
+        for key, value in values.items():
             ret = self.set(key, value, expire, noreply, flags=flags)
             if not ret:
                 result.append(key)
@@ -145,8 +144,8 @@ class MockMemcacheClient(object):
     def prepend(self, key, value, expire=0, noreply=True, flags=None):
         current = self.get(key)
         if current is not None:
-            if (isinstance(value, six.string_types) and
-                    not isinstance(value, six.binary_type)):
+            if (isinstance(value, str) and
+                    not isinstance(value, bytes)):
                 try:
                     value = value.encode(self.encoding)
                 except (UnicodeEncodeError, UnicodeDecodeError):
@@ -157,8 +156,8 @@ class MockMemcacheClient(object):
     def append(self, key, value, expire=0, noreply=True, flags=None):
         current = self.get(key)
         if current is not None:
-            if (isinstance(value, six.string_types) and
-                    not isinstance(value, six.binary_type)):
+            if (isinstance(value, str) and
+                    not isinstance(value, bytes)):
                 try:
                     value = value.encode(self.encoding)
                 except (UnicodeEncodeError, UnicodeDecodeError):

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,13 +20,6 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Topic :: Database
 
-[options]
-setup_requires =
-    six
-install_requires =
-    six
-packages = find:
-
 [bdist_wheel]
 universal = true
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ url = https://github.com/pinterest/pymemcache
 keywords = memcache, client, database
 classifiers =
     Programming Language :: Python
-    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,3 @@
-future
-mock
 pytest
 pytest-cov
 gevent==20.9.0; "PyPy" not in platform_python_implementation

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, py37, py38, py39, pypy, pypy3, flake8, integration
+envlist = py36, py37, py38, py39, pypy, pypy3, flake8, integration
 skip_missing_interpreters = True
 # Automatic envs (pyXX) will only use the python version appropriate to that
 # env and ignore basepython inherited from [testenv] if we set
@@ -20,6 +20,7 @@ commands =
     pip install -e .
     py.test {posargs:pymemcache/test/ -m integration}
 
+<<<<<<< HEAD
 [testenv:flake8]
 # Avoid pulling all the base requirements only to run flake8
 deps = flake8
@@ -28,6 +29,9 @@ commands =
     python setup.py check --restructuredtext
 
 [testenv:coverage]
+=======
+[testenv:py39-flake8]
+>>>>>>> 290ad0c (Drop python support 2.7, 3.4 and 3.5)
 commands =
     py.test --cov=pymemcache
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,6 @@ commands =
     pip install -e .
     py.test {posargs:pymemcache/test/ -m integration}
 
-<<<<<<< HEAD
 [testenv:flake8]
 # Avoid pulling all the base requirements only to run flake8
 deps = flake8
@@ -29,9 +28,6 @@ commands =
     python setup.py check --restructuredtext
 
 [testenv:coverage]
-=======
-[testenv:py39-flake8]
->>>>>>> 290ad0c (Drop python support 2.7, 3.4 and 3.5)
 commands =
     py.test --cov=pymemcache
 


### PR DESCRIPTION
End of Life information:
* 3.5 https://www.python.org/downloads/release/python-350/
* 3.4 https://www.python.org/downloads/release/python-340/
* 2.7 https://www.python.org/doc/sunset-python-2/

Remove six dependency and run pyupgrade to start using native python 3 syntax