### PR TITLE
[WIP] Adding retry management

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -174,6 +174,55 @@ the `JsonSerde` from above which is more careful with encodings:
             raise Exception("Unknown serialization format")
 
 
+Retrying with pymemcache
+------------------------
+
+Pymemcache afford retrying mechanismes. The ``RetryingClient`` module simplify
+the task of adding retry behavior to just about anything in pymemcache.
+
+The simplest use case is retrying a flaky function whenever an Exception
+occurs until a value is returned.
+
+Example:
+
+.. code-block:: python
+
+     from pymemcache import Client, RetryingClient
+
+     rc = retrying.RetryingClient(Client("127.0.01"))
+     rc.set("foo", "bar")
+
+In the previous example if an exception occur it will retry until retry limit
+is reached. It will catch all type of exceptions.
+
+.. code-block:: python
+
+     from pymemcache import Client, RetryingClient
+     from pymemcache.client.retrying import wait_random
+
+     rc = retrying.RetryingClient(
+        Client("127.0.01"),
+        wait=wait_random(min=1, max=9))
+     rc.set("foo", "bar")
+
+You can define your waiting strategy to use as in the previous example.
+
+
+.. code-block:: python
+
+     from pymemcache import Client, RetryingClient
+     from pymemcache.exception import MemcacheUnexpectedCloseError
+     from pymemcache.client.retrying import retry_if_exception
+
+     rc = retrying.RetryingClient(
+        Client("127.0.01"),
+        retry=retry_if_exception(MemcacheUnexpectedCloseError))
+     rc.set("foo", "bar")
+
+You can define your retry strategy by only acting on specific kind
+of exception.
+
+
 Interacting with pymemcache
 ---------------------------
 

--- a/pymemcache/__init__.py
+++ b/pymemcache/__init__.py
@@ -3,6 +3,7 @@ __version__ = '3.4.4'
 from pymemcache.client.base import Client  # noqa
 from pymemcache.client.base import PooledClient  # noqa
 from pymemcache.client.hash import HashClient  # noqa
+from pymemcache.client.retrying import RetryingClient  # noqa
 
 from pymemcache.exceptions import MemcacheError  # noqa
 from pymemcache.exceptions import MemcacheClientError  # noqa

--- a/pymemcache/client/retrying.py
+++ b/pymemcache/client/retrying.py
@@ -1,0 +1,183 @@
+import functools
+import inspect
+import time
+import logging
+
+import pymemcache.exceptions as pymemexception
+
+logger = logging.getLogger(__name__)
+
+default_strategies = {
+    'global'
+    'local'
+}
+
+
+class _retry_always(retry_base):
+    """Retry strategy that always rejects any result."""
+
+    def __call__(self, retry_state):
+        return True
+
+
+retry_always = _retry_always()
+
+
+class retry_if_exception(retry_base):
+    """Retry strategy that retries if an exception verifies a predicate."""
+
+    def __init__(self, predicate):
+        self.predicate = predicate
+
+    def __call__(self, retry_state):
+        if retry_state.outcome.failed:
+            return self.predicate(retry_state.outcome.exception())
+        else:
+            return False
+
+
+class retry_if_exception_type(retry_if_exception):
+    """Retries if an exception has been raised of one or more types."""
+
+    def __init__(self, exception_types=Exception):
+        self.exception_types = exception_types
+        super(retry_if_exception_type, self).__init__(
+            lambda e: isinstance(e, exception_types)
+        )
+
+
+class retry_if_not_exception_type(retry_if_exception):
+    """Retries except an exception has been raised of one or more types."""
+
+    def __init__(self, exception_types=Exception):
+        self.exception_types = exception_types
+        super(retry_if_not_exception_type, self).__init__(
+            lambda e: not isinstance(e, exception_types)
+        )
+
+
+class retry_unless_exception_type(retry_if_exception):
+    """Retries until an exception is raised of one or more types."""
+
+    def __init__(self, exception_types=Exception):
+        self.exception_types = exception_types
+        super(retry_unless_exception_type, self).__init__(
+            lambda e: not isinstance(e, exception_types)
+        )
+
+    def __call__(self, retry_state):
+        # always retry if no exception was raised
+        if not retry_state.outcome.failed:
+            return True
+        return self.predicate(retry_state.outcome.exception())
+
+
+class stop_any(stop_base):
+    """Stop if any of the stop condition is valid."""
+
+    def __init__(self, *stops):
+        self.stops = stops
+
+    def __call__(self, retry_state):
+        return any(x(retry_state) for x in self.stops)
+
+
+class stop_all(stop_base):
+    """Stop if all the stop conditions are valid."""
+
+    def __init__(self, *stops):
+        self.stops = stops
+
+    def __call__(self, retry_state):
+        return all(x(retry_state) for x in self.stops)
+
+
+class stop_never(stop_base):
+    """Never stop."""
+
+    def __call__(self, retry_state):
+        return False
+
+
+def retry(
+    func,
+    fretry,
+    stop,
+    wait,
+    reraise,
+    before,
+    after,
+    callback
+):
+    @functools.wraps(func)
+    def func_call(*args, **kwargs):
+        while True:
+            try:
+                return func(*args, **kwargs)
+            except Exception as e:
+                fretry()
+                print(e)
+                print(f"Error {ntries}")
+            finally:
+                ntries -= 1
+                time.sleep(2)
+    return func_call
+
+
+class RetryingClient(object):
+    """
+    A client for communicating with a cluster of memcached servers
+
+    strategy: template of retry strategy to use (default to 'global',
+        all kind of exception will lead to retry)
+    stop: Define when to stop retrying
+    wait: Define how time to wait before two attempts (fixed, random, exponential backoff)
+    reraise: Define if we should reraise the exceptions
+    before: Define an action to execute before each attempts
+    after: Define an action to execute after each attempts
+    callback: Define a callback function to execute after all retries failed
+    """
+
+    def _decorate_client(self):
+        """
+        Morphing the class into the passed client to proxify all his methods
+        call and then catch exceptions to start retrying over them.
+        """
+        for name, m in inspect.getmembers(self.client, inspect.ismethod):
+            if name.startswith("_"):
+                continue
+            # Binding client's methods to our current object and decorate
+            # them dynamically with our retry features.
+            setattr(
+                self,
+                name,
+                retry(
+                    m,
+                    self.retry
+                    self.stop,
+                    self.wait,
+                    self.reraise,
+                    self.before,
+                    self.after,
+                    self.callback
+            ))
+
+    def __init__(self,
+            client,
+            retry=retry_if_exception_type,
+            stop=stop_never,
+            wait,
+            reraise,
+            before,
+            after,
+            callback
+        ):
+        self.retry = retry
+        self.stop = stop
+        self.wait = wait
+        self.reraise = reraise
+        self.before = before
+        self.after = after
+        self.callback = callback
+        self.client = client
+        self._decorate_client()

--- a/pymemcache/test/test_retrying.py
+++ b/pymemcache/test/test_retrying.py
@@ -1,0 +1,109 @@
+# Copyright 2012 Pinterest.com
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from builtins import bytes as newbytes
+
+import collections
+import errno
+import functools
+import json
+import os
+import mock
+import re
+import socket
+import unittest
+
+import pytest
+
+from pymemcache.client.base import Client
+from pymemcache.exceptions import (
+    MemcacheClientError,
+    MemcacheServerError,
+    MemcacheUnknownCommandError,
+    MemcacheUnknownError,
+    MemcacheIllegalInputError
+)
+
+from pymemcache.test.utils import (
+    MockMemcacheClient,
+    MockSocket,
+    MockSocketModule
+)
+
+
+@pytest.mark.unit()
+class TestClientRetrying(unittest.TestCase):
+    def test_socket_connect_ipv4(self):
+        server = ('127.0.0.1', 11211)
+
+        client = RetryingClient(
+            Client(server, socket_module=MockSocketModule()))
+        
+        client._connect()
+        assert client.sock.connections == [server]
+        assert client.sock.family == socket.AF_INET
+
+        timeout = 2
+        connect_timeout = 3
+        client = Client(
+            server, connect_timeout=connect_timeout, timeout=timeout,
+            socket_module=MockSocketModule())
+        client._connect()
+        assert client.sock.timeouts == [connect_timeout, timeout]
+
+        client = Client(server, socket_module=MockSocketModule())
+        client._connect()
+        assert client.sock.socket_options == []
+
+        client = Client(
+            server, socket_module=MockSocketModule(), no_delay=True)
+        client._connect()
+        assert client.sock.socket_options == [(socket.IPPROTO_TCP,
+                                               socket.TCP_NODELAY, 1)]
+
+    def test_socket_connect_closes_on_failure(self):
+        server = ("example.com", 11211)
+
+        socket_module = MockSocketModule(connect_failure=OSError())
+        client = RetryingClient(
+            Client(server, socket_module=socket_module)
+        with pytest.raises(OSError):
+            client._connect()
+        assert len(socket_module.sockets) == 1
+        assert socket_module.sockets[0].connections == []
+        assert socket_module.sockets[0].closed
+
+    def test_socket_close(self):
+        server = ("example.com", 11211)
+
+        client = RetryingClient(
+            Client(server, socket_module=MockSocketModule()))
+        client._connect()
+        assert client.sock is not None
+
+        client.close()
+        assert client.sock is None
+
+    def test_socket_close_exception(self):
+        server = ("example.com", 11211)
+
+        socket_module = MockSocketModule(close_failure=OSError())
+        client = RetryingClient(
+            Client(server, socket_module=socket_module)
+        client._connect()
+        assert client.sock is not None
+
+        client.close()
+        assert client.sock is None

--- a/pymemcache/test/utils.py
+++ b/pymemcache/test/utils.py
@@ -15,6 +15,68 @@ from pymemcache.serde import LegacyWrappingSerde
 from pymemcache.client.base import check_key_helper
 
 
+class MockSocket(object):
+    def __init__(self, recv_bufs, connect_failure=None, close_failure=None):
+        self.recv_bufs = collections.deque(recv_bufs)
+        self.send_bufs = []
+        self.closed = False
+        self.timeouts = []
+        self.connect_failure = connect_failure
+        self.close_failure = close_failure
+        self.connections = []
+        self.socket_options = []
+
+    @property
+    def family(self):
+        # TODO: Use ipaddress module when dropping support for Python < 3.3
+        ipv6_re = re.compile(r'^[0-9a-f:]+$')
+        is_ipv6 = any(ipv6_re.match(c[0]) for c in self.connections)
+        return socket.AF_INET6 if is_ipv6 else socket.AF_INET
+
+    def sendall(self, value):
+        self.send_bufs.append(value)
+
+    def close(self):
+        if isinstance(self.close_failure, Exception):
+            raise self.close_failure
+        self.closed = True
+
+    def recv(self, size):
+        value = self.recv_bufs.popleft()
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    def settimeout(self, timeout):
+        self.timeouts.append(timeout)
+
+    def connect(self, server):
+        if isinstance(self.connect_failure, Exception):
+            raise self.connect_failure
+        self.connections.append(server)
+
+    def setsockopt(self, level, option, value):
+        self.socket_options.append((level, option, value))
+
+
+class MockSocketModule(object):
+    def __init__(self, connect_failure=None, close_failure=None):
+        self.connect_failure = connect_failure
+        self.close_failure = close_failure
+        self.sockets = []
+
+    def socket(self, family, type, proto=0, fileno=None):
+        socket = MockSocket(
+            [],
+            connect_failure=self.connect_failure,
+            close_failure=self.close_failure)
+        self.sockets.append(socket)
+        return socket
+
+    def __getattr__(self, name):
+        return getattr(socket, name)
+
+
 class MockMemcacheClient(object):
     """
     A (partial) in-memory mock for Clients.


### PR DESCRIPTION
Still work in progress.

The goal is to decorate all passed client dynamically to avoid technical
debt and API changes.

This module will only decorate passed client to manage uniformized and
standardized retries. It will be possible to configure the retry
strategies and mechanismes.

Here is just a PoC for now.