### PR TITLE
Client API for server shutdown protocol command

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -829,9 +829,6 @@ class Client(object):
         Args:
           graceful: optional bool, True to request a graceful shutdown with
                     SIGUSR1 (defaults to False, i.e. SIGINT shutdown).
-
-        Returns:
-          True.
         """
         cmd = b'shutdown'
         if graceful:
@@ -845,8 +842,6 @@ class Client(object):
             self._misc_cmd([cmd], b'shutdown', False)
         except MemcacheUnexpectedCloseError:
             pass
-
-        return True
 
     def _raise_errors(self, line, name):
         if line.startswith(b'ERROR'):

--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -844,7 +844,9 @@ class Client(object):
         try:
             self._misc_cmd([cmd], b'shutdown', False)
         except MemcacheUnexpectedCloseError:
-            return True
+            pass
+
+        return True
 
     def _raise_errors(self, line, name):
         if line.startswith(b'ERROR'):

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -692,7 +692,7 @@ class TestClient(ClientTestMixin, unittest.TestCase):
     def test_shutdown(self):
         client = self.make_client([MemcacheUnexpectedCloseError('shutdown')])
         result = client.shutdown()
-        assert result is True
+        assert result is None
 
     def test_shutdown_disabled(self):
         def _shutdown():

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -31,6 +31,7 @@ from pymemcache.client.base import PooledClient, Client, normalize_server_spec
 from pymemcache.exceptions import (
     MemcacheClientError,
     MemcacheServerError,
+    MemcacheUnexpectedCloseError,
     MemcacheUnknownCommandError,
     MemcacheUnknownError,
     MemcacheIllegalInputError
@@ -687,6 +688,19 @@ class TestClient(ClientTestMixin, unittest.TestCase):
         result = client.quit()
         assert result is None
         assert client.sock is None
+
+    def test_shutdown(self):
+        client = self.make_client([MemcacheUnexpectedCloseError('shutdown')])
+        result = client.shutdown()
+        assert result is True
+
+    def test_shutdown_disabled(self):
+        def _shutdown():
+            client = self.make_client([b'ERROR: shutdown not enabled\r\n'])
+            client.shutdown()
+
+        with pytest.raises(MemcacheUnknownCommandError):
+            _shutdown()
 
     def test_replace_stored(self):
         client = self.make_client([b'STORED\r\n'])


### PR DESCRIPTION
This change proposes the addition of a client API wrapper for the [`shutdown` text protocol command](https://github.com/memcached/memcached/blob/c472369fed5981ba8c004d426cee62d5165c47ca/doc/protocol.txt#L1698).

Minimal example usage:

```python
from pymemcache.client.base import Client


c = Client('localhost:11211')
c.shutdown(False)
```

When shutdown is not enabled on the server:

```
<28 new auto-negotiating client connection
28: Client using the ascii protocol
<28 shutdown
>28 ERROR: shutdown not enabled
<28 connection closed.
```

```
Traceback (most recent call last):
  File "driver.py", line 5, in <module>
    c.shutdown(False)
  File "/home/kiwi/sync/code/external/pymemcache/pymemcache/client/base.py", line 845, in shutdown
    self._misc_cmd([cmd], b'shutdown', False)
  File "/home/kiwi/sync/code/external/pymemcache/pymemcache/client/base.py", line 1045, in _misc_cmd
    self._raise_errors(line, cmd_name)
  File "/home/kiwi/sync/code/external/pymemcache/pymemcache/client/base.py", line 853, in _raise_errors
    raise MemcacheUnknownCommandError(name)
pymemcache.exceptions.MemcacheUnknownCommandError: b'shutdown'
```

When [`--enable-shutdown`](https://github.com/memcached/memcached/blob/c472369fed5981ba8c004d426cee62d5165c47ca/memcached.c#L4749) is specified at server runtime:

```
<28 new auto-negotiating client connection
28: Client using the ascii protocol
<28 shutdown
Signal handled: Interrupt.
<28 connection closed.
stopped assoc
asking workers to stop
asking background threads to stop
stopped lru crawler
stopped maintainer
stopped slab mover
stopped logger thread
stopped idle timeout thread
closing connections
<26 connection closed.
<27 connection closed.
reaping worker threads
all background threads stopped
```