### PR TITLE
Rely on tox for CI linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,8 @@ jobs:
     - name: Lint
       if: matrix.python-version == '2.7' || matrix.python-version == '3.9'
       run: |
-        pip install flake8
-        flake8
-        python setup.py check --restructuredtext
+        pip install tox tox-gh-actions
+        tox -e flake8
     - name: Disable IPv6 localhost
       run: |
         sudo sed -i '/::1/d' /etc/hosts

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,13 @@
 [tox]
-envlist = py27, py34, py35, py36, py37, py38, py39, pypy, pypy3, py27-flake8, py39-flake8, integration
+envlist = py27, py34, py35, py36, py37, py38, py39, pypy, pypy3, flake8, integration
 skip_missing_interpreters = True
+# Automatic envs (pyXX) will only use the python version appropriate to that
+# env and ignore basepython inherited from [testenv] if we set
+# ignore_basepython_conflict.
+ignore_basepython_conflict = True
 
 [testenv]
+basepython = python3
 setenv =
     PYTHONPATH = {toxinidir}
 deps = -r{toxinidir}/test-requirements.txt
@@ -15,16 +20,11 @@ commands =
     pip install -e .
     py.test {posargs:pymemcache/test/ -m integration}
 
-[testenv:py27-flake8]
+[testenv:flake8]
+# Avoid pulling all the base requirements only to run flake8
+deps = flake8
 commands =
-    pip install flake8
-    flake8 pymemcache/
-    python setup.py check --restructuredtext
-
-[testenv:py39-flake8]
-commands =
-    pip install flake8
-    flake8 pymemcache/
+    flake8
     python setup.py check --restructuredtext
 
 [testenv:docs]


### PR DESCRIPTION
These changes allow us to rely on tox when we execute our linters on CI.

They centralize the way we define our jobs and targets to use them
in standardized way locally and during CI pipelines.

With these changes we are sure to execute the same commands everywhere.