### PR TITLE
Remove codespell and flake8 complexity check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,8 @@ jobs:
     - name: Lint
       if: matrix.python-version == '2.7' || matrix.python-version == '3.9'
       run: |
-        pip install codespell flake8
-        codespell . --skip=./.*,./pymemcache/test/certs --quiet-level=2
-        flake8 --max-complexity=18 .
+        pip install flake8
+        flake8
         python setup.py check --restructuredtext
     - name: Disable IPv6 localhost
       run: |


### PR DESCRIPTION
I think the value provided by codespell is low and not worth the CPU
cycles to run it on ever change.

Also, the flake8 complexity check isn't particularly helpful (in my
opinion).