### PR TITLE
[py27] Fixing a bug with bad conditions

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -113,7 +113,7 @@ def check_key_helper(key, allow_unicode_keys, key_prefix=b''):
     if len(key) > 250:
         raise MemcacheIllegalInputError("Key is too long: %r" % key)
     # second statement catches leading or trailing whitespace
-    elif len(parts) > 1 or parts[0] != key:
+    elif len(parts) > 1 or (parts and parts[0] != key):
         raise MemcacheIllegalInputError("Key contains whitespace: %r" % key)
     elif b'\00' in key:
         raise MemcacheIllegalInputError("Key contains null: %r" % key)

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -55,7 +55,7 @@ def is_ipv6(address):
 
 
 @pytest.mark.parametrize(
-    'key, allow_unicode_keys,key_prefix,ex_exception,ex_excinfo,ignore_py27',
+    'key,allow_unicode_keys,key_prefix,ex_exception,ex_excinfo,ignore_py27',
     [
         (u'b'*251, True, b'',
          MemcacheIllegalInputError, 'Key is too long', False),

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -24,6 +24,7 @@ import mock
 import platform
 import re
 import socket
+import sys
 import unittest
 
 import pytest
@@ -32,7 +33,8 @@ from pymemcache.client.base import (
     PooledClient,
     Client,
     normalize_server_spec,
-    KeepaliveOpts
+    KeepaliveOpts,
+    check_key_helper
 )
 from pymemcache.exceptions import (
     MemcacheClientError,
@@ -50,6 +52,45 @@ from pymemcache.test.utils import MockMemcacheClient
 # TODO: Use ipaddress module when dropping support for Python < 3.3
 def is_ipv6(address):
     return re.match(r'^[0-9a-f:]+$', address)
+
+
+@pytest.mark.parametrize(
+    'key, allow_unicode_keys,key_prefix,ex_exception,ex_excinfo,ignore_py27',
+    [
+        (u'b'*251, True, b'',
+         MemcacheIllegalInputError, 'Key is too long', False),
+        (u'foo bar', True, b'',
+         MemcacheIllegalInputError, 'Key contains whitespace', False),
+        (u'\00', True, b'',
+         MemcacheIllegalInputError, 'Key contains null', False),
+        (None, True, b'', TypeError, None, False),
+        # The following test won't fail with a TypeError with python 2.7
+        (b"", False, '', TypeError, None, True),
+    ])
+@pytest.mark.unit()
+def test_check_key_helper_failing_conditions(key, allow_unicode_keys,
+                                             key_prefix, ex_exception,
+                                             ex_excinfo, ignore_py27):
+
+    if ignore_py27:
+        if sys.version_info < (3, 0, 0):
+            return
+    with pytest.raises(ex_exception) as excinfo:
+        check_key_helper(key, allow_unicode_keys, key_prefix)
+
+    # Allow to ignore the excinfo value. Different implementation (2.7,
+    # pypy, 3.x) comes with various error messages for the same thing.
+    # We just check the kind of the exception.
+    if ex_excinfo:
+        assert ex_excinfo in str(excinfo.value)
+
+
+@pytest.mark.unit()
+def test_check_key_helper():
+    assert check_key_helper(b"key", True, b'') == b"key"
+    assert check_key_helper("key", True) == b"key"
+    assert isinstance(check_key_helper(b"key", True), bytes)
+    assert check_key_helper("", True) == b""
 
 
 class MockSocket(object):

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -72,9 +72,8 @@ def test_check_key_helper_failing_conditions(key, allow_unicode_keys,
                                              key_prefix, ex_exception,
                                              ex_excinfo, ignore_py27):
 
-    if ignore_py27:
-        if sys.version_info < (3, 0, 0):
-            return
+    if ignore_py27 and sys.version_info < (3, 0, 0):
+        pytest.skip("skipping for Python 2.7")
     with pytest.raises(ex_exception) as excinfo:
         check_key_helper(key, allow_unicode_keys, key_prefix)
 


### PR DESCRIPTION
These changes fix a condition for python 2.7 only.

Python 3 and python 2.7 behave differently during our key handling.

With python 3, in the case where the key is empty and where the key is not a
bytes object the concatenation [1] will fail and the execution will be stoped
with the raise of a TypeError exception.

With python 2 the concatenation is not a problem and so the execution
isn't stoped and that lead us to a problematic condition few line below [2].
Here we execute a condition with a boolean logic and an `or` operator.
That mean that if the first condition doesn't return `True` we will
execute the second condition, in this case we will compare an index of a
previous split with our original key. The problem here is that if our
key is empty then we will try to retrieve the index `0` which will lead
us to an IndexError (empty list).

This error is allowed with python 2.7 because the previous concatenation
doesn't fail. The execution can continue.

These changes ensure that the list is not empty before trying to
retrieve an index. This is possible by using an `and` operator in the
second logic expression. This one will stop the execution and will
ignore the index part if the list is empty.

These changes also add few unittest to check more directly this
function.

The empty key lead to a specific concatenation behaviour which
depends-on the version of python used and lead us to the part bug with
the condition.

[1] https://github.com/pinterest/pymemcache/blob/master/pymemcache/client/base.py#L110
[2] https://github.com/pinterest/pymemcache/blob/master/pymemcache/client/base.py#L116