### PR TITLE
Allow us to import the KeepalivOpts from the root pymemcache namespace

### DIFF
--- a/pymemcache/__init__.py
+++ b/pymemcache/__init__.py
@@ -3,6 +3,7 @@ __version__ = '3.4.4'
 from pymemcache.client.base import Client  # noqa
 from pymemcache.client.base import PooledClient  # noqa
 from pymemcache.client.hash import HashClient  # noqa
+from pymemcache.client.base import KeepaliveOpts  # noqa
 
 from pymemcache.exceptions import MemcacheError  # noqa
 from pymemcache.exceptions import MemcacheClientError  # noqa


### PR DESCRIPTION
As this class aim to be used with all kind of clients it would be worth to allow to import it from the root namespace of pymemcache.

Else, without these changes, we will have to import it from `pymemcache.client.base`.

Examples without these changes:

```
>>> from pymemcache import KeepaliveOpts
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  ImportError: cannot import name 'KeepaliveOpts' from 'pymemcache'
  (/home/hberaud/pymemcache/pymemcache/__init
  __.py)
```

Examples with these changes:

```
>>> from pymemcache import KeepaliveOpts
>>>
```