### PR TITLE
Use sphinxcontrib-apidoc extension for readthedocs builds

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,3 +1,4 @@
 sphinx==3.0.3
 sphinx_rtd_theme
+sphinxcontrib-apidoc
 sphinxcontrib-napoleon

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.napoleon',
     'sphinx.ext.ifconfig',
+    'sphinxcontrib.apidoc',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -350,20 +351,7 @@ intersphinx_mapping = {'https://docs.python.org/': None}
 
 
 # Automate building apidoc when building with readthedocs
-# https://github.com/rtfd/readthedocs.org/issues/1139
-def run_apidoc(_):
-    module = 'pymemcache'
-    cur_dir = os.path.abspath(os.path.dirname(__file__))
-    output_path = os.path.join(cur_dir, 'apidoc')
-    module_path = os.path.join(cur_dir, '..', module)
-    cmd_path = 'sphinx-apidoc'
-    if hasattr(sys, 'real_prefix'):  # Check to see if we are in a virtualenv
-        # If we are, assemble the path manually
-        cmd_path = os.path.abspath(os.path.join(sys.prefix,
-                                                'bin', 'sphinx-apidoc'))
-    subprocess.check_call([cmd_path, '-e', '-o',
-                           output_path, module_path, '--force'])
-
-
-def setup(app):
-    app.connect('builder-inited', run_apidoc)
+apidoc_module_dir = os.path.join('..', 'pymemcache')
+apidoc_output_dir = 'apidoc'
+apidoc_separate_modules = True
+apidoc_extra_args = ['--force']

--- a/tox.ini
+++ b/tox.ini
@@ -34,8 +34,7 @@ commands =
 [testenv:docs]
 commands =
     pip install -r docs-requirements.txt
-    sphinx-apidoc -o docs/apidoc/ pymemcache
-    sphinx-build -b html docs/ docs/_build
+    sphinx-build -b html docs/ docs/_build/html
 
 [testenv:venv]
 commands = {posargs}


### PR DESCRIPTION
This PR replaces the `run_apidoc` event handler with the [sphinxcontrib-apidoc](https://github.com/sphinx-contrib/apidoc) extension. It does pretty much the same thing, but it's a little more convenient. Feel free to close this PR if you don't find that useful, but personally it's saved me quite a few headaches.

Notes:
* `apidoc_separate_modules` is equivalent to the `-e` option
* `apidoc_module_dir` and `apidoc_output_dir` are relative to the documentation source dir (`/docs`)
* I updated `tox.ini` so local Sphinx builds will use the apidoc config in `conf.py` instead of separately running the `sphinx-apidoc` command
* I added a `.readthedocs.yml` to install `docs-requirements.txt`. If you already have that configured in your settings on readthedocs.org, that file can be removed.