### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -289,7 +289,7 @@ class Client:
 
         Args:
           server: tuple(hostname, port) or string containing a UNIX socket path.
-          serde: optional seralizer object, see notes in the class docs.
+          serde: optional serializer object, see notes in the class docs.
           serializer: deprecated serialization function
           deserializer: deprecated deserialization function
           connect_timeout: optional float, seconds to wait for a connection to

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -188,7 +188,7 @@ class CustomizedClient(Client):
 class ClientTestMixin:
     def make_client(self, mock_socket_values, **kwargs):
         client = Client(None, **kwargs)
-        # mock out client._connect() rather than hard-settting client.sock to
+        # mock out client._connect() rather than hard-setting client.sock to
         # ensure methods are checking whether self.sock is None before
         # attempting to use it
         sock = MockSocket(list(mock_socket_values))
@@ -198,7 +198,7 @@ class ClientTestMixin:
 
     def make_customized_client(self, mock_socket_values, **kwargs):
         client = CustomizedClient(None, **kwargs)
-        # mock out client._connect() rather than hard-settting client.sock to
+        # mock out client._connect() rather than hard-setting client.sock to
         # ensure methods are checking whether self.sock is None before
         # attempting to use it
         sock = MockSocket(list(mock_socket_values))

--- a/pymemcache/test/test_client_retry.py
+++ b/pymemcache/test/test_client_retry.py
@@ -17,7 +17,7 @@ class TestRetryingClientPassthrough(ClientTestMixin, unittest.TestCase):
 
     def make_base_client(self, mock_socket_values, **kwargs):
         base_client = Client(None, **kwargs)
-        # mock out client._connect() rather than hard-settting client.sock to
+        # mock out client._connect() rather than hard-setting client.sock to
         # ensure methods are checking whether self.sock is None before
         # attempting to use it
         sock = MockSocket(list(mock_socket_values))
@@ -43,7 +43,7 @@ class TestRetryingClient(object):
     def make_base_client(self, mock_socket_values, **kwargs):
         """ Creates a regular mock client to wrap in the RetryClient. """
         base_client = Client(None, **kwargs)
-        # mock out client._connect() rather than hard-settting client.sock to
+        # mock out client._connect() rather than hard-setting client.sock to
         # ensure methods are checking whether self.sock is None before
         # attempting to use it
         sock = MockSocket(list(mock_socket_values))
@@ -104,7 +104,7 @@ class TestRetryingClient(object):
         with pytest.raises(ValueError):
             RetryingClient(base_client, retry_for="haha!")
 
-        # With collectino of string and exceptions?
+        # With collection of string and exceptions?
         with pytest.raises(ValueError):
             RetryingClient(base_client, retry_for=[Exception, str])
 
@@ -131,7 +131,7 @@ class TestRetryingClient(object):
         with pytest.raises(ValueError):
             RetryingClient(base_client, do_not_retry_for="haha!")
 
-        # With collectino of string and exceptions?
+        # With collection of string and exceptions?
         with pytest.raises(ValueError):
             RetryingClient(base_client, do_not_retry_for=[Exception, str])
 
@@ -294,7 +294,7 @@ class TestRetryingClient(object):
             client.get("key")
 
     def test_both_exception_filters(self):
-        # Test interacction between both exception filters.
+        # Test interaction between both exception filters.
         client = self.make_client(
             [
                 MemcacheClientError("Whoops."),


### PR DESCRIPTION
There are small typos in:
- pymemcache/client/base.py
- pymemcache/test/test_client.py
- pymemcache/test/test_client_retry.py

Fixes:
- Should read `setting` rather than `settting`.
- Should read `collection` rather than `collectino`.
- Should read `serializer` rather than `seralizer`.
- Should read `interaction` rather than `interacction`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md