### PR TITLE
Use default for get ignore_exc

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -1283,7 +1283,7 @@ class PooledClient:
                 return client.get(key, default)
             except Exception:
                 if self.ignore_exc:
-                    return None
+                    return default
                 else:
                     raise
 

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -360,6 +360,16 @@ class ClientTestMixin:
         result = client.get(b'key', default='foobar')
         assert result == 'foobar'
 
+    def test_get_ignore_exc_default(self):
+        client = self.make_client([b'INVALID DATA\r\n'], ignore_exc=True)
+        result = client.get(b'key', default='foobar')
+        assert result == 'foobar'
+
+        # Unit test for customized client (override _extract_value)
+        client = self.make_client([b'INVALID DATA\r\n'], ignore_exc=True)
+        result = client.get(b'key', default='foobar')
+        assert result == 'foobar'
+
     def test_get_found(self):
         client = self.make_client([
             b'STORED\r\n',


### PR DESCRIPTION
ignore_exc should treat an error as a cache miss and default specifies
what should be returned on a miss.

Fixes issue #350