### PR TITLE
Return default from hash client

### DIFF
--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -357,7 +357,8 @@ class HashClient:
         return self._run_cmd('set', key, False, *args, **kwargs)
 
     def get(self, key, *args, **kwargs):
-        return self._run_cmd('get', key, None, *args, **kwargs)
+        default = kwargs.get('default', None)
+        return self._run_cmd('get', key, default, *args, **kwargs)
 
     def incr(self, key, *args, **kwargs):
         return self._run_cmd('incr', key, False, *args, **kwargs)

--- a/pymemcache/test/test_client_hash.py
+++ b/pymemcache/test/test_client_hash.py
@@ -257,6 +257,8 @@ class TestHashClient(ClientTestMixin, unittest.TestCase):
 
         result = client.get('foo')
         assert result is None
+        result = client.get('foo', default='default')
+        assert result == 'default'
         result = client.set('foo', 'bar')
         assert result is False
 


### PR DESCRIPTION
When using `HashClient` with `ignore_exc`, `get` would always return
`None` if no server is available. The other clients return the default
value in this case.

Return the default value so `HashClient` behaves like the other
clients.

Fixes a variation of issue #350