### PR TITLE
Support noreply for hash flush_all

### DIFF
--- a/pymemcache/client/hash.py
+++ b/pymemcache/client/hash.py
@@ -438,9 +438,9 @@ class HashClient:
     def touch(self, key, *args, **kwargs):
         return self._run_cmd("touch", key, False, *args, **kwargs)
 
-    def flush_all(self):
+    def flush_all(self, *args, **kwargs):
         for client in self.clients.values():
-            self._safely_run_func(client, client.flush_all, False)
+            self._safely_run_func(client, client.flush_all, False, *args, **kwargs)
 
     def quit(self):
         for client in self.clients.values():

--- a/pymemcache/test/test_client_hash.py
+++ b/pymemcache/test/test_client_hash.py
@@ -374,6 +374,10 @@ class TestHashClient(ClientTestMixin, unittest.TestCase):
         result = client.set_many(values, noreply=True)
         assert result == []
 
+    def test_noreply_flush(self):
+        client = self.make_client()
+        client.flush_all(noreply=True)
+
     def test_set_many_unix(self):
         values = {"key1": "value1", "key2": "value2", "key3": "value3"}
 


### PR DESCRIPTION
The regular client supports noreply so pass args, kwargs like for other
functions in hash client

Fixes issue #360