### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: [3.7, 3.8, 3.9, pypy-3.7]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,13 +12,15 @@ keywords = memcache, client, database
 classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: Implementation :: PyPy
     License :: OSI Approved :: Apache Software License
     Topic :: Database
+
+[options]
+python_requires = >= 3.7
 
 [bdist_wheel]
 universal = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,14 @@
 [tox]
-envlist = py36, py37, py38, py39, pypy, pypy3, flake8, black, integration
+envlist = py37, py38, py39, pypy3, flake8, black, integration
 skip_missing_interpreters = True
 # Automatic envs (pyXX) will only use the python version appropriate to that
 # env and ignore basepython inherited from [testenv] if we set
 # ignore_basepython_conflict.
 ignore_basepython_conflict = True
+
+[gh-actions]
+python =
+    pypy-3.7: pypy3
 
 [testenv]
 basepython = python3


### PR DESCRIPTION
Python 3.6 reached the end of its life last year.