### PR TITLE
Update the list of Black target versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [tool.black]
-target-version = ['py36', 'py37', 'py38', 'py39']
+target-version = ['py37', 'py38', 'py39', 'py310']


### PR DESCRIPTION
We dropped support for Python 3.6 in efbe513 and introduced support for
Python 3.10 in a19947f.