### PR TITLE
Revise tox configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,24 +24,23 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-python-${{ matrix.python-version }}-pip-${{ hashFiles('setup.py') }}-${{ hashFiles('*-requirements.txt') }}
+        key: ${{ runner.os }}-python-${{ matrix.python-version }}-pip-${{ hashFiles('.github/workflows/ci.yml') }}
         restore-keys: ${{ runner.os }}-python-${{ matrix.python-version }}-pip
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        python -m pip install tox tox-gh-actions
         sudo apt-get install libmemcached-dev
     - name: Lint
       if: matrix.python-version == '3.10'
       run: |
-        pip install tox tox-gh-actions
-        tox -e flake8,black
+        tox -e lint
     - name: Disable IPv6 localhost
       run: |
         sudo sed -i '/::1/d' /etc/hosts
     - name: Tests
       run: |
-        pip install -r test-requirements.txt
-        py.test pymemcache/test/ \
+        tox -- pymemcache/test/ \
             -m 'unit or integration' \
             --port ${{ job.services.memcached.ports[11211] }} \
             --tls-port ${{ job.services.tls_memcached.ports[11211] }}

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,0 +1,4 @@
+black==22.1.0
+docutils==0.18.1
+flake8==4.0.1
+pygments==2.11.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,8 +42,10 @@ markers =
     unit
     integration
     benchmark
+testpaths =
+    pymemcache/test
 
 [flake8]
 show-source = True
-exclude = .tox/*,.venv/*,docs/*
+exclude = .eggs/*,.tox/*,.venv/*,docs/*
 extend-ignore = E203, E501

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,3 @@
-black==22.1.0
 pytest==7.0.1
 pytest-cov==3.0.0
 gevent==21.12.0; "PyPy" not in platform_python_implementation

--- a/tox.ini
+++ b/tox.ini
@@ -1,47 +1,38 @@
 [tox]
-envlist = py37, py38, py39, py310, pypy3, flake8, black, integration
-skip_missing_interpreters = True
-# Automatic envs (pyXX) will only use the python version appropriate to that
-# env and ignore basepython inherited from [testenv] if we set
-# ignore_basepython_conflict.
-ignore_basepython_conflict = True
+envlist =
+    py37,
+    py38,
+    py39,
+    py310,
+    pypy3,
+    docs,
+    lint,
+    venv,
+skip_missing_interpreters = true
 
 [gh-actions]
 python =
     pypy-3.7: pypy3
 
 [testenv]
-basepython = python3
-setenv =
-    PYTHONPATH = {toxinidir}
+description = run tests with {basepython}
 deps = -r{toxinidir}/test-requirements.txt
+skip_install = True
 commands =
-    pip install -e .
-    py.test {posargs:pymemcache/test/}
+    python -m pytest {posargs}
 
-[testenv:integration]
+[testenv:lint]
+description = lint source code
+deps = -r{toxinidir}/lint-requirements.txt
 commands =
-    pip install -e .
-    py.test {posargs:pymemcache/test/ -m integration}
-
-[testenv:flake8]
-# Avoid pulling all the base requirements only to run flake8
-deps = flake8
-commands =
+    python setup.py check --metadata --restructuredtext --strict
     flake8
-    python setup.py check --restructuredtext
-
-[testenv:black]
-commands =
     black --check .
 
-[testenv:coverage]
-commands =
-    py.test --cov=pymemcache
-
 [testenv:docs]
+description = invoke sphinx-build to build the HTML docs
+deps = -r{toxinidir}/docs-requirements.txt
 commands =
-    pip install -r docs-requirements.txt
     sphinx-build -b html docs/ docs/_build/html
 
 [testenv:venv]


### PR DESCRIPTION
This repositions tox as the "source of truth" for all development and CI
actions.

To support this, lint and test requirements have been split into
separate sets of requirements, and a consolidated 'lint' environment now
runs all of our lint checks. This is also used by CI.