### PR TITLE
Ignore noisy dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "mypy"
+      - dependency-name: "pytest"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
We're only interested in automatic dependency updates for minor (not
patch) pytest versions, and we don't need to track every incremental
mypy update.