### PR TITLE
Handle a blank stat value

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -1038,7 +1038,7 @@ class Client:
                     result[key] = value
                 elif name == b"stats" and line.startswith(b"STAT"):
                     key_value = line.split()
-                    result[key_value[1]] = key_value[2] if len(key_value) > 2 else b''
+                    result[key_value[1]] = key_value[2] if len(key_value) > 2 else b""
                 elif name == b"stats" and line.startswith(b"ITEM"):
                     # For 'stats cachedump' commands
                     key_value = line.split()

--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -1038,7 +1038,7 @@ class Client:
                     result[key] = value
                 elif name == b"stats" and line.startswith(b"STAT"):
                     key_value = line.split()
-                    result[key_value[1]] = key_value[2]
+                    result[key_value[1]] = key_value[2] if len(key_value) > 2 else b''
                 elif name == b"stats" and line.startswith(b"ITEM"):
                     # For 'stats cachedump' commands
                     key_value = line.split()

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -984,6 +984,11 @@ class TestClient(ClientTestMixin, unittest.TestCase):
         assert client.sock.send_bufs == [b"stats some_arg\r\n"]
         assert result == {b"fake_stats": 1}
 
+    def test_stats_with_blank_value(self):
+        client = self.make_client([b"STAT fake_stats \r\n", b"END\r\n"])
+        result = client.stats()
+        assert result == {b"fake_stats": b""}
+
     def test_stats_conversions(self):
         client = self.make_client(
             [


### PR DESCRIPTION
A stat with a blank value makes the .stats() call fail with index error.  

```
memcache_connection.stats() 
File "/lib/python3.6/site-packages/pymemcache/client/base.py", line 741, in stats 
result = self._fetch_cmd(b'stats', args, False) 
File "/lib/python3.6/site-packages/pymemcache/client/base.py", line 921, in _fetch_cmd 
result[key_value[1]] = key_value[2]
IndexError: list index out of range
```

The line in question we saw that caused this:

```
b'STAT ep_initfile '
```

This fixes things to no longer blow up.   I chose to use a blank binary string instead of None because I suspect other code might make assumptions about the data being binary strings due to this bug.   