### PR TITLE
Small buffer pass optimization as discussed in #395.

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -1446,7 +1446,7 @@ def _readline(sock, buf):
         else:
             token_pos = buf.find(b"\r\n")
             if token_pos != -1:
-                # Note, magic constant: Two/2 is the length of the token in find.
+                # Note: 2 == len(b"\r\n")
                 before, after = buf[:token_pos], buf[token_pos + 2 :]
                 chunks.append(before)
                 return after, b"".join(chunks)

--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -1443,10 +1443,13 @@ def _readline(sock, buf):
             # Strip the last character from the last chunk.
             chunks[-1] = chunks[-1][:-1]
             return buf[1:], b"".join(chunks)
-        elif buf.find(b"\r\n") != -1:
-            before, sep, after = buf.partition(b"\r\n")
-            chunks.append(before)
-            return after, b"".join(chunks)
+        else:
+            token_pos = buf.find(b"\r\n")
+            if token_pos != -1:
+                # Note, magic constant: Two/2 is the length of the token in find.
+                before, after = buf[:token_pos], buf[token_pos + 2 :]
+                chunks.append(before)
+                return after, b"".join(chunks)
 
         if buf:
             chunks.append(buf)


### PR DESCRIPTION
Basically ensure the client only does one pass over the buffer instead of two.
Exact thread: https://github.com/pinterest/pymemcache/pull/395#discussion_r890288417
