### PR TITLE
Add py.typed file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.* ChangeLog.* setup.py setup.cfg LICENSE.txt
 include *-requirements.txt tox.ini
+include pymemcache/py.typed
 recursive-include pymemcache *.py
 recursive-include pymemcache/test *.crt
 recursive-include pymemcache/test *.key


### PR DESCRIPTION
As per https://peps.python.org/pep-0561/ add a py.typed file to let things like mypy there is inline typing information