### PR TITLE
Fix key_prefix issue with stats and cache_memlimit

### DIFF
--- a/pymemcache/test/conftest.py
+++ b/pymemcache/test/conftest.py
@@ -1,7 +1,8 @@
 import os.path
-import pytest
 import socket
 import ssl
+
+import pytest
 
 
 def pytest_addoption(parser):
@@ -100,7 +101,7 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize("socket_module", socket_modules)
 
     if "client_class" in metafunc.fixturenames:
-        from pymemcache.client.base import PooledClient, Client
+        from pymemcache.client.base import Client, PooledClient
         from pymemcache.client.hash import HashClient
 
         class HashClientSingle(HashClient):
@@ -108,3 +109,8 @@ def pytest_generate_tests(metafunc):
                 super().__init__([server], *args, **kwargs)
 
         metafunc.parametrize("client_class", [Client, PooledClient, HashClientSingle])
+
+    if "key_prefix" in metafunc.fixturenames:
+        mark = metafunc.definition.get_closest_marker("parametrize")
+        if not mark or "key_prefix" not in mark.args[0]:
+            metafunc.parametrize("key_prefix", [b"", b"prefix"])

--- a/pymemcache/test/test_integration.py
+++ b/pymemcache/test/test_integration.py
@@ -12,21 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import defaultdict
 import json
-import pytest
+from collections import defaultdict
 
+import pytest
 from pymemcache.client.base import Client
 from pymemcache.exceptions import (
-    MemcacheIllegalInputError,
     MemcacheClientError,
+    MemcacheIllegalInputError,
     MemcacheServerError,
 )
-from pymemcache.serde import (
-    compressed_serde,
-    PickleSerde,
-    pickle_serde,
-)
+from pymemcache.serde import PickleSerde, compressed_serde, pickle_serde
 
 
 def get_set_helper(client, key, value, key2, value2):
@@ -56,8 +52,10 @@ def get_set_helper(client, key, value, key2, value2):
         compressed_serde,
     ],
 )
-def test_get_set(client_class, host, port, serde, socket_module):
-    client = client_class((host, port), serde=serde, socket_module=socket_module)
+def test_get_set(client_class, host, port, serde, socket_module, key_prefix):
+    client = client_class(
+        (host, port), serde=serde, socket_module=socket_module, key_prefix=key_prefix
+    )
     client.flush_all()
 
     key = b"key"
@@ -75,9 +73,15 @@ def test_get_set(client_class, host, port, serde, socket_module):
         compressed_serde,
     ],
 )
-def test_get_set_unicode_key(client_class, host, port, serde, socket_module):
+def test_get_set_unicode_key(
+    client_class, host, port, serde, socket_module, key_prefix
+):
     client = client_class(
-        (host, port), serde=serde, socket_module=socket_module, allow_unicode_keys=True
+        (host, port),
+        serde=serde,
+        socket_module=socket_module,
+        allow_unicode_keys=True,
+        key_prefix=key_prefix,
     )
     client.flush_all()
 
@@ -96,8 +100,10 @@ def test_get_set_unicode_key(client_class, host, port, serde, socket_module):
         compressed_serde,
     ],
 )
-def test_add_replace(client_class, host, port, serde, socket_module):
-    client = client_class((host, port), serde=serde, socket_module=socket_module)
+def test_add_replace(client_class, host, port, serde, socket_module, key_prefix):
+    client = client_class(
+        (host, port), serde=serde, socket_module=socket_module, key_prefix=key_prefix
+    )
     client.flush_all()
 
     result = client.add(b"key", b"value", noreply=False)
@@ -122,8 +128,10 @@ def test_add_replace(client_class, host, port, serde, socket_module):
 
 
 @pytest.mark.integration()
-def test_append_prepend(client_class, host, port, socket_module):
-    client = client_class((host, port), socket_module=socket_module)
+def test_append_prepend(client_class, host, port, socket_module, key_prefix):
+    client = client_class(
+        (host, port), socket_module=socket_module, key_prefix=key_prefix
+    )
     client.flush_all()
 
     result = client.append(b"key", b"value", noreply=False)
@@ -150,8 +158,10 @@ def test_append_prepend(client_class, host, port, socket_module):
 
 
 @pytest.mark.integration()
-def test_cas(client_class, host, port, socket_module):
-    client = client_class((host, port), socket_module=socket_module)
+def test_cas(client_class, host, port, socket_module, key_prefix):
+    client = client_class(
+        (host, port), socket_module=socket_module, key_prefix=key_prefix
+    )
     client.flush_all()
     result = client.cas(b"key", b"value", b"1", noreply=False)
     assert result is None
@@ -178,8 +188,10 @@ def test_cas(client_class, host, port, socket_module):
 
 
 @pytest.mark.integration()
-def test_gets(client_class, host, port, socket_module):
-    client = client_class((host, port), socket_module=socket_module)
+def test_gets(client_class, host, port, socket_module, key_prefix):
+    client = client_class(
+        (host, port), socket_module=socket_module, key_prefix=key_prefix
+    )
     client.flush_all()
 
     result = client.gets(b"key")
@@ -192,8 +204,10 @@ def test_gets(client_class, host, port, socket_module):
 
 
 @pytest.mark.integration()
-def test_delete(client_class, host, port, socket_module):
-    client = client_class((host, port), socket_module=socket_module)
+def test_delete(client_class, host, port, socket_module, key_prefix):
+    client = client_class(
+        (host, port), socket_module=socket_module, key_prefix=key_prefix
+    )
     client.flush_all()
 
     result = client.delete(b"key", noreply=False)
@@ -210,8 +224,8 @@ def test_delete(client_class, host, port, socket_module):
 
 
 @pytest.mark.integration()
-def test_incr_decr(client_class, host, port, socket_module):
-    client = Client((host, port), socket_module=socket_module)
+def test_incr_decr(client_class, host, port, socket_module, key_prefix):
+    client = Client((host, port), socket_module=socket_module, key_prefix=key_prefix)
     client.flush_all()
 
     result = client.incr(b"key", 1, noreply=False)
@@ -238,8 +252,10 @@ def test_incr_decr(client_class, host, port, socket_module):
 
 
 @pytest.mark.integration()
-def test_touch(client_class, host, port, socket_module):
-    client = client_class((host, port), socket_module=socket_module)
+def test_touch(client_class, host, port, socket_module, key_prefix):
+    client = client_class(
+        (host, port), socket_module=socket_module, key_prefix=key_prefix
+    )
     client.flush_all()
 
     result = client.touch(b"key", noreply=False)
@@ -256,9 +272,15 @@ def test_touch(client_class, host, port, socket_module):
 
 
 @pytest.mark.integration()
-def test_misc(client_class, host, port, socket_module):
-    client = Client((host, port), socket_module=socket_module)
+def test_misc(client_class, host, port, socket_module, key_prefix):
+    client = Client((host, port), socket_module=socket_module, key_prefix=key_prefix)
     client.flush_all()
+
+    # Ensure no exceptions are thrown
+    client.stats("cachedump", "1", "1")
+
+    success = client.cache_memlimit(50)
+    assert success
 
 
 @pytest.mark.integration()


### PR DESCRIPTION
Add integration tests to reproduce the issue and add an argument to _fetch_cmd to skip the key prefix logic as needed.

Closes #430