### PR TITLE
Update project urls to include link to docs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,9 @@ description = A comprehensive, fast, pure Python memcached client
 long_description = file: README.rst, ChangeLog.rst
 long_description_content_type = text/x-rst
 license = Apache License 2.0
-url = https://github.com/pinterest/pymemcache
+project_urls =
+    Documentation = https://pymemcache.readthedocs.io/
+    Source = https://github.com/pinterest/pymemcache
 keywords = memcache, client, database
 classifiers =
     Programming Language :: Python


### PR DESCRIPTION
Make it easier to find the documentation from https://pypi.org/project/pymemcache/

https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls