### PR TITLE
Bump `pylibmc` version to avoid installation error while creating the dev env.

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,6 +2,6 @@ Faker==15.1.0
 pytest==7.2.0
 pytest-cov==4.0.0
 gevent==22.10.1; "PyPy" not in platform_python_implementation
-pylibmc==1.6.1; sys.platform != 'win32'
+pylibmc==1.6.3; sys.platform != 'win32'
 python-memcached==1.59
 zstd==1.5.2.5


### PR DESCRIPTION
More detailed info here:
https://github.com/lericson/pylibmc/issues/284