### PR TITLE
Fix `KeyError` caused by wrong key type. #450 

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -1104,7 +1104,7 @@ class Client:
         except MemcacheUnexpectedCloseError:
             self.close()
             raise
-        original_key = remapped_keys[key]
+        original_key = remapped_keys.get(key, "")
         value = self.serde.deserialize(original_key, value, int(flags))
 
         if expect_cas:


### PR DESCRIPTION
Fix `KeyError` caused by wrong key type. #450 