### PR TITLE
fix test serde failure on 32-bit platforms

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,6 +137,7 @@ Credits
 * `Hervé Beraud <https://github.com/4383>`_
 * `Martin Jørgensen <https://github.com/martinnj>`_
 * `Matej Spiller Muys <https://github.com/matejsp>`_
+* `misuzu <https://github.com/misuzu>`_
 
 We're Hiring!
 =============

--- a/pymemcache/test/test_serde.py
+++ b/pymemcache/test/test_serde.py
@@ -12,7 +12,6 @@ from pymemcache.serde import (
 )
 import pytest
 import pickle
-import sys
 import zlib
 
 
@@ -128,7 +127,7 @@ def test_compressed_complex(serde):
     check(serde, "£ $ €" * 10, FLAG_TEXT | FLAG_COMPRESSED)
 
     # test_int, doesn't make sense to compress
-    check(serde, sys.maxsize, FLAG_INTEGER)
+    check(serde, 9223372036854775807, FLAG_INTEGER)
 
     # test_pickleable
     check(
@@ -144,4 +143,4 @@ def test_compressed_complex(serde):
 
     # test_subtype
     # Subclass of a native type will be restored as the same type
-    check(serde, CustomInt(sys.maxsize), FLAG_PICKLE | FLAG_COMPRESSED)
+    check(serde, CustomInt(9223372036854775807), FLAG_PICKLE | FLAG_COMPRESSED)


### PR DESCRIPTION
Closes #479

This test was written with the assumption
that sys.maxsize is equal to 2**63 - 1 everywhere.

sys.maxsize is equal to 2**31 - 1 on a 32-bit
platforms and 2**63 - 1 on a 64-bit platforms.

See also https://docs.python.org/3/library/sys.html#sys.maxsize