### PR TITLE
Propagate encoding from PooledClient to internal Client

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -1447,6 +1447,7 @@ class PooledClient:
             key_prefix=self.key_prefix,
             default_noreply=self.default_noreply,
             allow_unicode_keys=self.allow_unicode_keys,
+            encoding=self.encoding,
             tls_context=self.tls_context,
         )
 


### PR DESCRIPTION
Using `PooledClient` class, the provided encoding is not set on the internal `Client` class so that it defaults to "ascii" and leads to encoding exceptions in case Unicode content is provided.

This small PR propagates the chosen encoding for the PooledClient instance to the created internal Client instances.