### PR TITLE
Remove unused 'mock' variable

### DIFF
--- a/pymemcache/test/test_ext_aws_ec_client.py
+++ b/pymemcache/test/test_ext_aws_ec_client.py
@@ -38,7 +38,7 @@ def test_init_valid_node_endpoint(connection_sting, monkeypatch):
 def test_init_invalid_node_endpoint(connection_sting, monkeypatch):
     with patch.object(
         AWSElastiCacheHashClient, "reconfigure_nodes", new=MagicMock()
-    ) as mock:
+    ):
         with pytest.raises(ValueError):
             AWSElastiCacheHashClient(connection_sting, socket_module=MockSocketModule())
 

--- a/pymemcache/test/test_ext_aws_ec_client.py
+++ b/pymemcache/test/test_ext_aws_ec_client.py
@@ -36,9 +36,7 @@ def test_init_valid_node_endpoint(connection_sting, monkeypatch):
     ],
 )
 def test_init_invalid_node_endpoint(connection_sting, monkeypatch):
-    with patch.object(
-        AWSElastiCacheHashClient, "reconfigure_nodes", new=MagicMock()
-    ):
+    with patch.object(AWSElastiCacheHashClient, "reconfigure_nodes", new=MagicMock()):
         with pytest.raises(ValueError):
             AWSElastiCacheHashClient(connection_sting, socket_module=MockSocketModule())
 


### PR DESCRIPTION
This was causing a lint error:

    ./pymemcache/test/test_ext_aws_ec_client.py:41:10: F841 local variable 'mock' is assigned to but never used