### PR TITLE
_parse_hex function should declare the base as 16 not 8

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -72,7 +72,7 @@ def _parse_float(value: bytes) -> float:
 
 
 def _parse_hex(value: bytes) -> int:
-    return int(value, 8)
+    return int(value, 16)
 
 
 STAT_TYPES: dict[bytes, Callable[[bytes], Any]] = {


### PR DESCRIPTION
https://github.com/pinterest/pymemcache/issues/633
