### PR TITLE
Fixed  issue for MemcacheUnknownCommandError

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -1169,8 +1169,8 @@ class Client:
             expire_bytes = self._check_integer(expire, "expire")
             cmd += b" " + expire_bytes
 
-        if prefixed_keys:
-            cmd += b" " + b" ".join(prefixed_keys)
+        #if prefixed_keys:
+            #cmd += b" " + b" ".join(prefixed_keys)
         cmd += b"\r\n"
 
         try:


### PR DESCRIPTION
**[Issue_link](https://github.com/pinterest/pymemcache/issues/550)**

In _recv method socket.recv() raising ERROR\r\n

```python
cmd = name
        if prefixed_keys:
            cmd += b" " + b" ".join(prefixed_keys)
        cmd += b"\r\n"
```
In above code for cmd we are sending args to  now cmd will be b'stats get_hits\r\n' we are sending this cmd to socket.sendall() so socket.recv(size) raise issue **MemcacheUnknownCommandError**

After making changes comment out below lines

```python
 if prefixed_keys:
            cmd += b" " + b" ".join(prefixed_keys)
```