### PR TITLE
PooledClient bug fix: add default, cas_default kwargs to gets

### DIFF
--- a/pymemcache/client/base.py
+++ b/pymemcache/client/base.py
@@ -1574,10 +1574,12 @@ class PooledClient:
 
     get_multi = get_many
 
-    def gets(self, key: Key) -> tuple[Any, Any]:
+    def gets(
+        self, key: Key, default: Any = None, cas_default: Any = None
+    ) -> tuple[Any, Any]:
         with self.client_pool.get_and_release(destroy_on_fail=True) as client:
             try:
-                return client.gets(key)
+                return client.gets(key, default=default, cas_default=cas_default)
             except Exception:
                 if self.ignore_exc:
                     return (None, None)

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -1447,6 +1447,36 @@ class TestPooledClient(ClientTestMixin, unittest.TestCase):
         result = client.gets(b"key")
         assert result == (b"value", b"10")
 
+    def test_cas_stored(self):
+        client = self.make_client([b"STORED\r\n"])
+        result = client.cas(b"key", b"value", b"123", noreply=False)
+        assert result is True
+
+        # unit test for encoding passed in __init__()
+        client = self.make_client([b"STORED\r\n"], encoding="utf-8")
+        result = client.cas(b"key", b"value", b"123", noreply=False)
+        assert result is True
+
+    def test_cas_exists(self):
+        client = self.make_client([b"EXISTS\r\n"])
+        result = client.cas(b"key", b"value", b"123", noreply=False)
+        assert result is False
+
+        # unit test for encoding passed in __init__()
+        client = self.make_client([b"EXISTS\r\n"], encoding="utf-8")
+        result = client.cas(b"key", b"value", b"123", noreply=False)
+        assert result is False
+
+    def test_cas_not_found(self):
+        client = self.make_client([b"NOT_FOUND\r\n"])
+        result = client.cas(b"key", b"value", b"123", noreply=False)
+        assert result is None
+
+        # unit test for encoding passed in __init__()
+        client = self.make_client([b"NOT_FOUND\r\n"], encoding="utf-8")
+        result = client.cas(b"key", b"value", b"123", noreply=False)
+        assert result is None
+
 
 class TestPooledClientIdleTimeout(ClientTestMixin, unittest.TestCase):
     def make_client(self, mock_socket_values, **kwargs):

--- a/pymemcache/test/test_client.py
+++ b/pymemcache/test/test_client.py
@@ -1432,6 +1432,21 @@ class TestPooledClient(ClientTestMixin, unittest.TestCase):
         client.client_class = MyClient
         assert isinstance(client.client_pool.get(), MyClient)
 
+    def test_gets_not_found(self):
+        client = self.make_client([b"END\r\n"])
+        result = client.gets(b"key")
+        assert result == (None, None)
+
+    def test_gets_not_found_defaults(self):
+        client = self.make_client([b"END\r\n"])
+        result = client.gets(b"key", default="foo", cas_default="bar")
+        assert result == ("foo", "bar")
+
+    def test_gets_found(self):
+        client = self.make_client([b"VALUE key 0 5 10\r\nvalue\r\nEND\r\n"])
+        result = client.gets(b"key")
+        assert result == (b"value", b"10")
+
 
 class TestPooledClientIdleTimeout(ClientTestMixin, unittest.TestCase):
     def make_client(self, mock_socket_values, **kwargs):


### PR DESCRIPTION
This makes PooledClient.gets usable. Thanks in advance for looking!