### PR TITLE
Added high-level diagrams

### DIFF
--- a/.codeboarding/Client_Wrappers_Extensions.md
+++ b/.codeboarding/Client_Wrappers_Extensions.md
@@ -1,0 +1,115 @@
+```mermaid
+
+graph LR
+
+    Client_API_Base_Client_["Client API (Base Client)"]
+
+    Hashing_Routing_Hash_Client_["Hashing/Routing (Hash Client)"]
+
+    Retry_Mechanism_Retrying_Client_["Retry Mechanism (Retrying Client)"]
+
+    AWS_ElastiCache_Extension["AWS ElastiCache Extension"]
+
+    Hashing_Routing_Hash_Client_ -- "manages" --> Client_API_Base_Client_
+
+    Retry_Mechanism_Retrying_Client_ -- "wraps" --> Client_API_Base_Client_
+
+    Retry_Mechanism_Retrying_Client_ -- "wraps" --> Hashing_Routing_Hash_Client_
+
+    AWS_ElastiCache_Extension -- "extends" --> Hashing_Routing_Hash_Client_
+
+    AWS_ElastiCache_Extension -- "uses" --> Client_API_Base_Client_
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The Client Wrappers & Extensions subsystem in pymemcache provides enhanced client functionalities by building upon core client implementations. This design adheres to the "Extension/Plugin Architecture" and "Decorator Pattern" to add features like fault tolerance and dynamic cloud environment integration without altering the fundamental client logic.
+
+
+
+### Client API (Base Client)
+
+This is the foundational component, representing the basic interface for interacting with a single Memcached server. It encapsulates the direct network communication, handles socket operations, and implements the core Memcached protocol commands (e.g., set, get, delete). It also manages serialization and deserialization of data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/pymemcache/blob/master/pymemcache/client/base.py#L1-L1" target="_blank" rel="noopener noreferrer">`pymemcache.client.base` (1:1)</a>
+
+
+
+
+
+### Hashing/Routing (Hash Client)
+
+This component extends the capabilities of the Base Client to manage interactions with multiple Memcached servers, forming a cluster. It employs a hashing algorithm (like Rendezvous Hash) to determine which server a given key should be routed to. It also incorporates basic mechanisms for handling server failures and retrying operations within the cluster.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/pymemcache/blob/master/pymemcache/client/hash.py#L1-L1" target="_blank" rel="noopener noreferrer">`pymemcache.client.hash` (1:1)</a>
+
+
+
+
+
+### Retry Mechanism (Retrying Client)
+
+This component acts as a wrapper (following the decorator pattern) around any other client (e.g., Base Client or Hash Client) to introduce automatic retry logic. It intercepts client calls and, in case of specified exceptions (e.g., network issues), re-attempts the operation a configurable number of times with a delay.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/pymemcache/blob/master/pymemcache/client/retrying.py#L1-L1" target="_blank" rel="noopener noreferrer">`pymemcache.client.retrying` (1:1)</a>
+
+
+
+
+
+### AWS ElastiCache Extension
+
+This specialized client is built upon the Hash Client and provides dynamic node discovery and management specifically for AWS ElastiCache clusters. It automates the process of identifying and connecting to cluster nodes by querying the ElastiCache configuration endpoint, eliminating the need for manual configuration updates when the cluster scales or changes.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/pymemcache/blob/master/pymemcache/client/ext/aws_ec_client.py#L1-L1" target="_blank" rel="noopener noreferrer">`pymemcache.client.ext.aws_ec_client` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Core_Memcached_Client.md
+++ b/.codeboarding/Core_Memcached_Client.md
@@ -1,0 +1,183 @@
+```mermaid
+
+graph LR
+
+    Core_Memcached_Client["Core Memcached Client"]
+
+    Pooled_Memcached_Client["Pooled Memcached Client"]
+
+    Hashed_Memcached_Client["Hashed Memcached Client"]
+
+    Serialization_Deserialization_Module["Serialization/Deserialization Module"]
+
+    Exception_Handling_Module["Exception Handling Module"]
+
+    Rendezvous_Hashing_Algorithm["Rendezvous Hashing Algorithm"]
+
+    Object_Pool["Object Pool"]
+
+    Pooled_Memcached_Client -- "inherits from" --> Core_Memcached_Client
+
+    Pooled_Memcached_Client -- "composes" --> Object_Pool
+
+    Hashed_Memcached_Client -- "inherits from" --> Core_Memcached_Client
+
+    Hashed_Memcached_Client -- "uses" --> Rendezvous_Hashing_Algorithm
+
+    Core_Memcached_Client -- "uses" --> Serialization_Deserialization_Module
+
+    Core_Memcached_Client -- "raises" --> Exception_Handling_Module
+
+    Pooled_Memcached_Client -- "uses" --> Serialization_Deserialization_Module
+
+    Hashed_Memcached_Client -- "uses" --> Serialization_Deserialization_Module
+
+    click Core_Memcached_Client href "https://github.com/pinterest/pymemcache/blob/master/.codeboarding//Core_Memcached_Client.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `pymemcache` library is structured around a clear layered architecture, with a foundational `Client` component handling low-level interactions, and higher-level clients building upon it for advanced features like connection pooling and multi-server management. Serialization and exception handling are modularized, promoting separation of concerns.
+
+
+
+### Core Memcached Client [[Expand]](./Core_Memcached_Client.md)
+
+This is the fundamental interface for interacting with a single Memcached server. It manages the TCP/UNIX socket connection, sends Memcached commands (e.g., `set`, `get`, `delete`), parses responses, and integrates with the serialization/deserialization mechanism. It handles the low-level protocol details and serves as the base for all other client implementations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/pymemcache/blob/master/pymemcache/client/base.py#L178-L1356" target="_blank" rel="noopener noreferrer">`pymemcache.client.base.Client` (178:1356)</a>
+
+
+
+
+
+### Pooled Memcached Client
+
+Extends the `Core Memcached Client` to provide connection pooling. Instead of opening and closing a connection for each operation, it reuses existing connections from a pool, improving performance and reducing overhead, especially in high-concurrency environments.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `pymemcache.client.pooled.PooledClient`
+
+
+
+
+
+### Hashed Memcached Client
+
+Extends the `Core Memcached Client` to manage interactions with multiple Memcached servers. It uses a hashing algorithm (like Rendezvous Hashing) to determine which server a particular key should be stored on or retrieved from, enabling distributed caching.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/pymemcache/blob/master/pymemcache/client/hash.py#L17-L469" target="_blank" rel="noopener noreferrer">`pymemcache.client.hash.HashClient` (17:469)</a>
+
+
+
+
+
+### Serialization/Deserialization Module
+
+This module provides the mechanisms for converting Python objects into bytes suitable for storage in Memcached and vice-versa. It defines default serializers (e.g., `LegacyWrappingSerde`, `PickleSerde`) and allows for custom serialization logic.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/pymemcache/blob/master/pymemcache/serde.py" target="_blank" rel="noopener noreferrer">`pymemcache.serde`</a>
+
+
+
+
+
+### Exception Handling Module
+
+Defines custom exception classes specific to Memcached operations (e.g., `MemcacheError`, `MemcacheClientError`, `MemcacheServerError`). These exceptions provide more granular error reporting than generic network or I/O errors, helping developers diagnose issues related to Memcached interactions.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/pymemcache/blob/master/pymemcache/exceptions.py" target="_blank" rel="noopener noreferrer">`pymemcache.exceptions`</a>
+
+
+
+
+
+### Rendezvous Hashing Algorithm
+
+Implements the Rendezvous Hashing (HRW) algorithm, which is used by the `HashClient` to consistently map keys to servers in a distributed Memcached setup. This algorithm minimizes key remapping when servers are added or removed, improving cache hit rates.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/pymemcache/blob/master/pymemcache/client/rendezvous.py#L3-L45" target="_blank" rel="noopener noreferrer">`pymemcache.client.rendezvous.RendezvousHash` (3:45)</a>
+
+
+
+
+
+### Object Pool
+
+A generic object pooling utility used by the `PooledClient` to manage and reuse `Client` instances (connections). It handles the creation, borrowing, and returning of objects to the pool, and can manage idle timeouts.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/pymemcache/blob/master/pymemcache/pool.py#L25-L134" target="_blank" rel="noopener noreferrer">`pymemcache.pool.ObjectPool` (25:134)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Multi_Server_Client_Hashing.md
+++ b/.codeboarding/Multi_Server_Client_Hashing.md
@@ -1,0 +1,183 @@
+```mermaid
+
+graph LR
+
+    HashClient["HashClient"]
+
+    RendezvousHash["RendezvousHash"]
+
+    Client["Client"]
+
+    murmur3["murmur3"]
+
+    PooledClient["PooledClient"]
+
+    Serialization_Deserialization_Module["Serialization/Deserialization Module"]
+
+    MemcacheError["MemcacheError"]
+
+    HashClient -- "Manages/Uses" --> Client
+
+    HashClient -- "Composes/Uses" --> RendezvousHash
+
+    RendezvousHash -- "Depends on" --> murmur3
+
+    Client -- "Uses" --> Serialization_Deserialization_Module
+
+    Client -- "Raises/Handles" --> MemcacheError
+
+    PooledClient -- "Inherits from" --> Client
+
+    Serialization_Deserialization_Module -- "Used by" --> Client
+
+    MemcacheError -- "Inherited by" --> specific_error_types
+
+    click Client href "https://github.com/pinterest/pymemcache/blob/master/.codeboarding//Client.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `Multi-Server Client & Hashing` subsystem in `pymemcache` is fundamental for enabling distributed caching across multiple Memcached servers. It achieves this by extending the basic single-server client functionality with intelligent key routing using consistent hashing.
+
+
+
+### HashClient
+
+The primary client interface for interacting with multiple Memcached servers. It abstracts away the complexity of routing keys to the correct server by employing a consistent hashing algorithm, enabling distributed caching and fault tolerance. It manages a collection of individual `Client` instances, one for each server.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/pymemcache/blob/master/pymemcache/client/hash.py" target="_blank" rel="noopener noreferrer">`pymemcache.client.hash`</a>
+
+
+
+
+
+### RendezvousHash
+
+Implements the Rendezvous Hashing (HRW) algorithm, a consistent hashing technique crucial for `HashClient`. It deterministically distributes keys among a dynamic set of servers, ensuring that when servers are added or removed, only a minimal number of keys need to be remapped, thus reducing cache misses.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/pymemcache/blob/master/pymemcache/client/rendezvous.py" target="_blank" rel="noopener noreferrer">`pymemcache.client.rendezvous`</a>
+
+
+
+
+
+### Client [[Expand]](./Client.md)
+
+The foundational client class responsible for direct, low-level communication with a single Memcached server. It handles the Memcached protocol interactions, serialization/deserialization of data, and basic error handling. `HashClient` builds upon this class by managing multiple instances of it.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/pymemcache/blob/master/pymemcache/client/base.py" target="_blank" rel="noopener noreferrer">`pymemcache.client.base`</a>
+
+
+
+
+
+### murmur3
+
+This module provides the Murmur3 hash function, a fast, non-cryptographic hash function. It is specifically used by the `RendezvousHash` algorithm to compute hash values for server keys and data keys, which is essential for the deterministic distribution of keys.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/pymemcache/blob/master/pymemcache/client/murmur3.py" target="_blank" rel="noopener noreferrer">`pymemcache.client.murmur3`</a>
+
+
+
+
+
+### PooledClient
+
+A specialized client that extends the `Client` class to manage a pool of connections to a single Memcached server. This improves performance by reusing established connections rather than opening new ones for each operation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `pymemcache.client.pooled`
+
+
+
+
+
+### Serialization/Deserialization Module
+
+This module provides the mechanisms for converting Python objects into a format suitable for storage in Memcached (serialization) and converting them back into Python objects upon retrieval (deserialization). It supports various serialization methods.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/pymemcache/blob/master/pymemcache/serde.py" target="_blank" rel="noopener noreferrer">`pymemcache.serde`</a>
+
+
+
+
+
+### MemcacheError
+
+The base class for all exceptions raised by the `pymemcache` client library, indicating various issues that can occur during Memcached operations (e.g., network errors, server errors, input errors).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/pymemcache/blob/master/pymemcache/exceptions.py" target="_blank" rel="noopener noreferrer">`pymemcache.exceptions`</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,153 @@
+```mermaid
+
+graph LR
+
+    Core_Memcached_Client["Core Memcached Client"]
+
+    Connection_Management["Connection Management"]
+
+    Multi_Server_Client_Hashing["Multi-Server Client & Hashing"]
+
+    Serialization_Deserialization["Serialization/Deserialization"]
+
+    Client_Wrappers_Extensions["Client Wrappers & Extensions"]
+
+    Core_Memcached_Client -- "uses" --> Serialization_Deserialization
+
+    Connection_Management -- "manages" --> Core_Memcached_Client
+
+    Multi_Server_Client_Hashing -- "manages" --> Core_Memcached_Client
+
+    Multi_Server_Client_Hashing -- "uses" --> Serialization_Deserialization
+
+    Client_Wrappers_Extensions -- "wraps" --> Core_Memcached_Client
+
+    Client_Wrappers_Extensions -- "extends" --> Multi_Server_Client_Hashing
+
+    click Core_Memcached_Client href "https://github.com/pinterest/pymemcache/blob/master/.codeboarding//Core_Memcached_Client.md" "Details"
+
+    click Multi_Server_Client_Hashing href "https://github.com/pinterest/pymemcache/blob/master/.codeboarding//Multi_Server_Client_Hashing.md" "Details"
+
+    click Client_Wrappers_Extensions href "https://github.com/pinterest/pymemcache/blob/master/.codeboarding//Client_Wrappers_Extensions.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+Abstract Components Overview
+
+
+
+### Core Memcached Client [[Expand]](./Core_Memcached_Client.md)
+
+The fundamental interface for interacting with a single Memcached server, handling low-level protocol, command execution, and direct connection management. It serves as the base for all higher-level client functionalities.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/pymemcache/blob/master/pymemcache/client/base.py#L178-L1356" target="_blank" rel="noopener noreferrer">`pymemcache.client.base.Client` (178:1356)</a>
+
+
+
+
+
+### Connection Management
+
+Manages a pool of `Core Memcached Client` instances to efficiently reuse network connections, thereby reducing the overhead associated with establishing new connections for each operation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/pymemcache/blob/master/pymemcache/pool.py#L25-L134" target="_blank" rel="noopener noreferrer">`pymemcache.pool.ObjectPool` (25:134)</a>
+
+- <a href="https://github.com/pinterest/pymemcache/blob/master/pymemcache/client/base.py#L1359-L1674" target="_blank" rel="noopener noreferrer">`pymemcache.client.base.PooledClient` (1359:1674)</a>
+
+
+
+
+
+### Multi-Server Client & Hashing [[Expand]](./Multi_Server_Client_Hashing.md)
+
+Extends client functionality to support interactions with multiple Memcached servers. It utilizes consistent hashing algorithms (e.g., Rendezvous Hash) to deterministically route keys to specific servers, enabling distributed caching and fault tolerance.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/pymemcache/blob/master/pymemcache/client/hash.py#L17-L469" target="_blank" rel="noopener noreferrer">`pymemcache.client.hash.HashClient` (17:469)</a>
+
+- <a href="https://github.com/pinterest/pymemcache/blob/master/pymemcache/client/rendezvous.py#L3-L45" target="_blank" rel="noopener noreferrer">`pymemcache.client.rendezvous.RendezvousHash` (3:45)</a>
+
+
+
+
+
+### Serialization/Deserialization
+
+A dedicated module responsible for converting Python objects into a byte format suitable for storage in Memcached, and vice-versa. It supports various serialization methods (e.g., Pickle) and compression.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/pymemcache/blob/master/pymemcache/serde.py#L96-L121" target="_blank" rel="noopener noreferrer">`pymemcache.serde.PickleSerde` (96:121)</a>
+
+- <a href="https://github.com/pinterest/pymemcache/blob/master/pymemcache/serde.py#L127-L167" target="_blank" rel="noopener noreferrer">`pymemcache.serde.CompressedSerde` (127:167)</a>
+
+- <a href="https://github.com/pinterest/pymemcache/blob/master/pymemcache/serde.py#L173-L192" target="_blank" rel="noopener noreferrer">`pymemcache.serde.LegacyWrappingSerde` (173:192)</a>
+
+
+
+
+
+### Client Wrappers & Extensions [[Expand]](./Client_Wrappers_Extensions.md)
+
+Provides higher-level client implementations that wrap core or multi-server clients to add specialized functionalities. This includes automatic retries for transient network issues and dynamic node discovery for cloud environments like AWS ElastiCache.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/pinterest/pymemcache/blob/master/pymemcache/client/retrying.py#L45-L176" target="_blank" rel="noopener noreferrer">`pymemcache.client.retrying.RetryingClient` (45:176)</a>
+
+- <a href="https://github.com/pinterest/pymemcache/blob/master/pymemcache/client/ext/aws_ec_client.py#L20-L204" target="_blank" rel="noopener noreferrer">`pymemcache.client.ext.aws_ec_client.AWSElastiCacheHashClient` (20:204)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
In this PR, I am adding a diagram visualizaiton for the git-stracktrace project.
I can see that you keep your `docs` as .rst files and build them with sphinx. I can integrate the diagrams within those if you like them (also we have a free github action to keep the whole thing up-to-date with new commits).

You can see how the diagrams in this change render here: https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/pymemcache/on_boarding.md

The goal of these documents is to help people get up to speed quickly with the git-stacktrace codebase. The diagrams are designed to give immediate overview of the codebase and allow you to dig deeper into each component of interest. The whole visualization is generated so it is easy to keep up-to-date. The generation is done via StaticAnalysis and LLMs.

Would love to connect and discuss how can we help the people who work and contributo to pinterest's codebase. We are curious to hear how do you keep docs up-to-date so that people can get up-to-speed to different projects within the company!

Any feedback is more than welcome!

Full disclosure: we're trying to turn this into a startup, but we're still in a very early stage and figuring out what will actually be useful for people.