### PR TITLE
MockMemcacheClient.set: assert that expire is an integer

### DIFF
--- a/pymemcache/test/utils.py
+++ b/pymemcache/test/utils.py
@@ -102,6 +102,7 @@ class MockMemcacheClient:
 
         value, flags = self.serde.serialize(key, value)
 
+        assert isinstance(expire, int), expire
         if expire:
             expire += time.time()
 


### PR DESCRIPTION
the real client does this, so ideally the mock should too.