### PR TITLE
MockMemcacheClient: add missing noreply, default_noreply support

### DIFF
--- a/pymemcache/test/test_utils.py
+++ b/pymemcache/test/test_utils.py
@@ -125,6 +125,35 @@ def test_incr_decr():
 
 
 @pytest.mark.unit()
+def test_default_noreply():
+    client = MockMemcacheClient(default_noreply=False)
+
+    assert client.add(b"k", 2) is True
+    assert client.add(b"k", 25) is False
+    assert client.delete(b"k") is True
+    assert client.delete(b"k") is False
+
+
+@pytest.mark.unit()
+def test_default_noreply_true():
+    client = MockMemcacheClient(default_noreply=True)
+
+    assert client.add(b"k", 2) is True
+    assert client.add(b"k", 25) is True
+    assert client.delete(b"k") is True
+    assert client.delete(b"missing") is True
+
+
+@pytest.mark.unit()
+def test_noreply_arg_overrides_default():
+    client = MockMemcacheClient(default_noreply=True)
+
+    assert client.add(b"k", 2, noreply=False) is True
+    assert client.add(b"k", 25, noreply=False) is False
+    assert client.delete(b"missing", noreply=False) is False
+
+
+@pytest.mark.unit()
 def test_prepand_append():
     client = MockMemcacheClient()
 

--- a/pymemcache/test/utils.py
+++ b/pymemcache/test/utils.py
@@ -49,6 +49,7 @@ class MockMemcacheClient:
 
         self.serde = serde or LegacyWrappingSerde(serializer, deserializer)
         self.allow_unicode_keys = allow_unicode_keys
+        self.default_noreply = default_noreply
 
         # Unused, but present for interface compatibility
         self.server = server
@@ -92,7 +93,9 @@ class MockMemcacheClient:
 
     get_multi = get_many
 
-    def set(self, key, value, expire=0, noreply=True, flags=None):
+    def set(self, key, value, expire=0, noreply=None, flags=None):
+        if noreply is None:
+            noreply = self.default_noreply
         key = self.check_key(key)
         if isinstance(value, str) and not isinstance(value, bytes):
             try:
@@ -108,7 +111,9 @@ class MockMemcacheClient:
         self._contents[key] = expire, value, flags
         return True
 
-    def set_many(self, values, expire=0, noreply=True, flags=None):
+    def set_many(self, values, expire=0, noreply=None, flags=None):
+        if noreply is None:
+            noreply = self.default_noreply
         result = []
         for key, value in values.items():
             ret = self.set(key, value, expire, noreply, flags=flags)
@@ -132,25 +137,33 @@ class MockMemcacheClient:
             self.set(key, current - value, noreply=noreply)
         return None if noreply or not present else current - value
 
-    def add(self, key, value, expire=0, noreply=True, flags=None):
+    def add(self, key, value, expire=0, noreply=None, flags=None):
+        if noreply is None:
+            noreply = self.default_noreply
         current = self.get(key)
         present = current is not None
         if not present:
             self.set(key, value, expire, noreply, flags=flags)
         return noreply or not present
 
-    def delete(self, key, noreply=True):
+    def delete(self, key, noreply=None):
+        if noreply is None:
+            noreply = self.default_noreply
         key = self.check_key(key)
         current = self._contents.pop(key, None)
         present = current is not None
         return noreply or present
 
-    def delete_many(self, keys, noreply=True):
+    def delete_many(self, keys, noreply=None):
+        if noreply is None:
+            noreply = self.default_noreply
         for key in keys:
             self.delete(key, noreply)
         return True
 
-    def prepend(self, key, value, expire=0, noreply=True, flags=None):
+    def prepend(self, key, value, expire=0, noreply=None, flags=None):
+        if noreply is None:
+            noreply = self.default_noreply
         current = self.get(key)
         if current is not None:
             if isinstance(value, str) and not isinstance(value, bytes):
@@ -161,7 +174,9 @@ class MockMemcacheClient:
             self.set(key, value + current, expire, noreply, flags=flags)
         return True
 
-    def append(self, key, value, expire=0, noreply=True, flags=None):
+    def append(self, key, value, expire=0, noreply=None, flags=None):
+        if noreply is None:
+            noreply = self.default_noreply
         current = self.get(key)
         if current is not None:
             if isinstance(value, str) and not isinstance(value, bytes):
@@ -206,7 +221,9 @@ class MockMemcacheClient:
     def cas(self, key, value, cas, expire=0, noreply=False, flags=None):
         raise MemcacheClientError("CAS is not enabled for this instance")
 
-    def touch(self, key, expire=0, noreply=True):
+    def touch(self, key, expire=0, noreply=None):
+        if noreply is None:
+            noreply = self.default_noreply
         current = self.get(key)
         present = current is not None
         if present:
@@ -219,7 +236,9 @@ class MockMemcacheClient:
     def version(self):
         return "MockMemcacheClient"
 
-    def flush_all(self, delay=0, noreply=True):
+    def flush_all(self, delay=0, noreply=None):
+        if noreply is None:
+            noreply = self.default_noreply
         self.clear()
 
         return noreply or self._contents == {}


### PR DESCRIPTION
Hi all! Not sure how maintained pymemcache is these days, but this bit me recently,
so I thought I'd contributed it upstream. Thanks in advance!